### PR TITLE
Add company and user models

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,7 +11,9 @@ def create_app():
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
     db.init_app(app)
-    
+
+    # Import models so that create_all can see them
+    from .models import Empresa, Usuario, Column, Card  # noqa: F401
 
     from .routes import main
     app.register_blueprint(main)

--- a/app/models.py
+++ b/app/models.py
@@ -1,14 +1,46 @@
 from . import db
 
+
+class Empresa(db.Model):
+    __tablename__ = 'empresas'
+
+    id = db.Column(db.Integer, primary_key=True)
+    nome = db.Column(db.String(120), nullable=False)
+    account_id = db.Column(db.String(120), unique=True, nullable=False)
+
+    columns = db.relationship('Column', backref='empresa', cascade='all, delete', lazy=True)
+    usuarios = db.relationship('Usuario', backref='empresa', cascade='all, delete', lazy=True)
+
+
+class Usuario(db.Model):
+    __tablename__ = 'usuarios'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.String(120), nullable=False)
+    user_email = db.Column(db.String(120), nullable=False)
+    user_name = db.Column(db.String(120), nullable=False)
+    role = db.Column(db.String(50), nullable=False)
+    empresa_id = db.Column(db.Integer, db.ForeignKey('empresas.id'), nullable=False)
+
+    cards = db.relationship('Card', backref='usuario', lazy=True)
+
+
 class Column(db.Model):
     __tablename__ = 'columns'
+
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(80), nullable=False)
+    empresa_id = db.Column(db.Integer, db.ForeignKey('empresas.id'), nullable=False)
+
     cards = db.relationship('Card', backref='column', cascade='all, delete', lazy=True)
+
 
 class Card(db.Model):
     __tablename__ = 'cards'
+
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(120), nullable=False)
     description = db.Column(db.String(300))
     column_id = db.Column(db.Integer, db.ForeignKey('columns.id'), nullable=False)
+    usuario_id = db.Column(db.Integer, db.ForeignKey('usuarios.id'))
+


### PR DESCRIPTION
## Summary
- create new `Empresa` and `Usuario` models
- add references from `Column` and `Card`
- import models in app factory so `db.create_all()` generates all tables

## Testing
- `python -m py_compile app/*.py`
- `pytest -q` *(fails: no tests)*
- `pip install -r requirements.txt` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687a251c63a4832d98c77b118191ea08