### PR TITLE
Implement session auth and access control

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,8 +17,10 @@ def create_app():
 
     from .routes import main
     from .webhook import webhook_bp
+    from .auth import auth_bp
     app.register_blueprint(main)
     app.register_blueprint(webhook_bp)
+    app.register_blueprint(auth_bp)
 
     with app.app_context():
         db.create_all()

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,64 @@
+from functools import wraps
+from flask import Blueprint, session, g, redirect, url_for
+
+from .models import Usuario
+
+
+auth_bp = Blueprint('auth', __name__)
+
+
+def login_user(usuario: Usuario) -> None:
+    """Persist logged in user info in the session."""
+    session['usuario_id'] = usuario.id
+    session['empresa_id'] = usuario.empresa_id
+    g.user = usuario
+
+
+def logout_user() -> None:
+    """Clear session information."""
+    session.clear()
+    g.user = None
+
+
+@auth_bp.before_app_request
+def load_logged_in_user():
+    """Load user from the session and store in ``g.user``."""
+    user_id = session.get('usuario_id')
+    if user_id is None:
+        g.user = None
+    else:
+        g.user = Usuario.query.get(user_id)
+
+
+@auth_bp.route('/logout')
+def logout():
+    """Simple logout route."""
+    logout_user()
+    return redirect(url_for('main.index'))
+
+
+def login_required(view):
+    """Ensure the user is logged in."""
+
+    @wraps(view)
+    def wrapped_view(**kwargs):
+        if g.get('user') is None:
+            return redirect(url_for('main.index'))
+        return view(**kwargs)
+
+    return wrapped_view
+
+
+def gestor_required(view):
+    """Allow access only for gestores."""
+
+    @wraps(view)
+    def wrapped_view(**kwargs):
+        if g.get('user') is None:
+            return redirect(url_for('main.index'))
+        if g.user.role != 'gestor':
+            return 'Acesso restrito aos gestores', 403
+        return view(**kwargs)
+
+    return wrapped_view
+

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,75 +1,122 @@
-from flask import Blueprint, render_template, request, redirect, url_for
+from flask import Blueprint, render_template, request, redirect, url_for, g, abort
 from .models import db, Column, Card
 from flask import jsonify
+from .auth import login_required, gestor_required
 
 main = Blueprint('main', __name__)
 
 @main.route('/', methods=['GET', 'POST'])
+@login_required
 def index():
-    columns = Column.query.all()
+    columns = Column.query.filter_by(empresa_id=g.user.empresa_id).all()
     return render_template('index.html', columns=columns)
 
 # Column CRUD
 @main.route('/add_column', methods=['POST'])
+@login_required
+@gestor_required
 def add_column():
     name = request.form['name']
-    column = Column(name=name)
+    column = Column(name=name, empresa_id=g.user.empresa_id)
     db.session.add(column)
     db.session.commit()
     return redirect(url_for('main.index'))
 
 @main.route('/edit_column/<int:column_id>', methods=['POST'])
+@login_required
+@gestor_required
 def edit_column(column_id):
     column = Column.query.get_or_404(column_id)
+    if column.empresa_id != g.user.empresa_id:
+        abort(404)
     column.name = request.form['name']
     db.session.commit()
     return redirect(url_for('main.index'))
 
 @main.route('/delete_column/<int:column_id>', methods=['POST'])
+@login_required
+@gestor_required
 def delete_column(column_id):
     column = Column.query.get_or_404(column_id)
+    if column.empresa_id != g.user.empresa_id:
+        abort(404)
     db.session.delete(column)
     db.session.commit()
     return '', 204
 
 @main.route('/add_card/<int:column_id>', methods=['POST'])
+@login_required
 def add_card(column_id):
+    column = Column.query.get_or_404(column_id)
+    if column.empresa_id != g.user.empresa_id:
+        abort(404)
     title = request.form['title']
     description = request.form.get('description', '')
-    card = Card(title=title, description=description, column_id=column_id)
+    card = Card(
+        title=title,
+        description=description,
+        column_id=column_id,
+        usuario_id=g.user.id,
+    )
     db.session.add(card)
     db.session.commit()
     return redirect(url_for('main.index'))
 
 @main.route('/edit_card/<int:card_id>', methods=['POST'])
+@login_required
 def edit_card(card_id):
     card = Card.query.get_or_404(card_id)
+    if card.column.empresa_id != g.user.empresa_id:
+        abort(404)
+    if g.user.role != 'gestor' and card.usuario_id != g.user.id:
+        return 'Acesso negado', 403
     card.title = request.form['title']
     card.description = request.form.get('description', '')
     db.session.commit()
     return redirect(url_for('main.index'))
 
 @main.route('/delete_card/<int:card_id>', methods=['POST'])
+@login_required
 def delete_card(card_id):
     card = Card.query.get_or_404(card_id)
+    if card.column.empresa_id != g.user.empresa_id:
+        abort(404)
+    if g.user.role != 'gestor' and card.usuario_id != g.user.id:
+        return 'Acesso negado', 403
     db.session.delete(card)
     db.session.commit()
     return '', 204  # Para AJAX deletar sem erro
 
 @main.route('/move_card/<int:card_id>', methods=['POST'])
+@login_required
 def move_card(card_id):
     card = Card.query.get_or_404(card_id)
+    if card.column.empresa_id != g.user.empresa_id:
+        abort(404)
+    if g.user.role != 'gestor' and card.usuario_id != g.user.id:
+        return 'Acesso negado', 403
     new_column_id = int(request.form['new_column_id'])
+    column = Column.query.get_or_404(new_column_id)
+    if column.empresa_id != g.user.empresa_id:
+        abort(404)
     card.column_id = new_column_id
     db.session.commit()
     return redirect(url_for('main.index'))
 
 @main.route('/api/move_card', methods=['POST'])
+@login_required
 def api_move_card():
     data = request.get_json()
     card_id = int(data['card_id'])
     new_column_id = int(data['column_id'])
     card = Card.query.get_or_404(card_id)
+    if card.column.empresa_id != g.user.empresa_id:
+        return jsonify({'success': False}), 404
+    if g.user.role != 'gestor' and card.usuario_id != g.user.id:
+        return jsonify({'success': False}), 403
+    column = Column.query.get_or_404(new_column_id)
+    if column.empresa_id != g.user.empresa_id:
+        return jsonify({'success': False}), 404
     card.column_id = new_column_id
     db.session.commit()
     return jsonify({'success': True})

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -1,5 +1,6 @@
-from flask import Blueprint, request, jsonify, session
+from flask import Blueprint, request, jsonify
 from .models import db, Empresa, Usuario
+from .auth import login_user
 import json
 
 webhook_bp = Blueprint('webhook', __name__)
@@ -42,7 +43,6 @@ def chatwoot_webhook():
         db.session.add(usuario)
         db.session.commit()
 
-    session['empresa_id'] = empresa.id
-    session['usuario_id'] = usuario.id
+    login_user(usuario)
 
     return jsonify({'success': True})


### PR DESCRIPTION
## Summary
- implement session login/logout helpers and decorators
- hook webhook login to new login_user function
- register auth blueprint
- restrict board routes by role and company

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a26c2b928832db447aa3638a2936a