### PR TITLE
Update superadmin features and board filtering

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, request, redirect, url_for, g, abort
+from flask import Blueprint, render_template, request, redirect, url_for, g, abort, session
 from .models import db, Column, Card
 from flask import jsonify
 from .auth import login_required, gestor_required
@@ -8,7 +8,8 @@ main = Blueprint('main', __name__)
 @main.route('/', methods=['GET', 'POST'])
 @login_required
 def index():
-    columns = Column.query.filter_by(empresa_id=g.user.empresa_id).all()
+    empresa_id = session.get('empresa_id', g.user.empresa_id)
+    columns = Column.query.filter_by(empresa_id=empresa_id).all()
     return render_template('index.html', columns=columns)
 
 # Column CRUD

--- a/app/superadmin.py
+++ b/app/superadmin.py
@@ -45,7 +45,7 @@ def edit_empresa(empresa_id):
         empresa.account_id = request.form['account_id']
         db.session.commit()
         return redirect(url_for('superadmin.dashboard'))
-    return render_template('superadmin/create_empresa.html', empresa=empresa)
+    return render_template('superadmin/edit_empresa.html', empresa=empresa)
 
 
 @superadmin_bp.route('/delete_empresa/<int:empresa_id>', methods=['POST'])
@@ -85,7 +85,7 @@ def edit_usuario(usuario_id):
         usuario.empresa_id = int(request.form['empresa_id'])
         db.session.commit()
         return redirect(url_for('superadmin.dashboard'))
-    return render_template('superadmin/create_usuario.html', usuario=usuario, empresas=empresas)
+    return render_template('superadmin/edit_usuario.html', usuario=usuario, empresas=empresas)
 
 
 @superadmin_bp.route('/delete_usuario/<int:usuario_id>', methods=['POST'])

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -47,7 +47,7 @@
         <button class="btn btn-success" type="submit">Adicionar Coluna</button>
     </form>
     <div class="kanban-board">
-        {% for column in columns %}
+        {% for column in columns if column.empresa_id == session['empresa_id'] %}
         <div class="kanban-column" data-column-id="{{ column.id }}">
             <div class="kanban-header d-flex align-items-center justify-content-between mb-2">
                 <span class="fw-bold fs-5">
@@ -58,7 +58,7 @@
                 </span>
             </div>
             <div class="kanban-cards" id="column-{{ column.id }}">
-                {% for card in column.cards %}
+                {% for card in column.cards if card.column.empresa_id == session['empresa_id'] %}
                 <div class="kanban-card" 
                      draggable="true"
                      data-card-id="{{ card.id }}"

--- a/app/templates/superadmin/dashboard.html
+++ b/app/templates/superadmin/dashboard.html
@@ -1,8 +1,28 @@
 <h2>Painel Super-Admin</h2>
 <a href="{{ url_for('superadmin.create_empresa', token=session['superadmin_token']) }}">Nova Empresa</a> |
 <a href="{{ url_for('superadmin.create_usuario', token=session['superadmin_token']) }}">Novo Usuário/Gestor</a>
+<h3>Empresas</h3>
 <ul>
     {% for emp in empresas %}
-        <li>{{ emp.nome }} (Account ID: {{ emp.account_id }})</li>
+        <li>
+            {{ emp.nome }} (Account ID: {{ emp.account_id }})
+            <a href="{{ url_for('superadmin.edit_empresa', empresa_id=emp.id, token=session['superadmin_token']) }}">Editar</a>
+            <form method="post" action="{{ url_for('superadmin.delete_empresa', empresa_id=emp.id, token=session['superadmin_token']) }}" style="display:inline;">
+                <button type="submit">Deletar</button>
+            </form>
+        </li>
+    {% endfor %}
+</ul>
+
+<h3>Usuários</h3>
+<ul>
+    {% for usr in usuarios %}
+        <li>
+            {{ usr.user_name }} - {{ usr.user_email }}
+            <a href="{{ url_for('superadmin.edit_usuario', usuario_id=usr.id, token=session['superadmin_token']) }}">Editar</a>
+            <form method="post" action="{{ url_for('superadmin.delete_usuario', usuario_id=usr.id, token=session['superadmin_token']) }}" style="display:inline;">
+                <button type="submit">Deletar</button>
+            </form>
+        </li>
     {% endfor %}
 </ul>

--- a/app/templates/superadmin/edit_empresa.html
+++ b/app/templates/superadmin/edit_empresa.html
@@ -1,0 +1,6 @@
+<form method="post">
+    <label>Nome Empresa</label><input type="text" name="nome" value="{{ empresa.nome }}"><br>
+    <label>Account ID</label><input type="text" name="account_id" value="{{ empresa.account_id }}"><br>
+    <input type="hidden" name="token" value="{{ request.args.get('token') }}">
+    <button type="submit">Salvar</button>
+</form>

--- a/app/templates/superadmin/edit_usuario.html
+++ b/app/templates/superadmin/edit_usuario.html
@@ -1,0 +1,19 @@
+<form method="post">
+    <label>User ID</label><input type="text" name="user_id" value="{{ usuario.user_id }}"><br>
+    <label>User Email</label><input type="email" name="user_email" value="{{ usuario.user_email }}"><br>
+    <label>User Name</label><input type="text" name="user_name" value="{{ usuario.user_name }}"><br>
+    <label>Empresa</label>
+    <select name="empresa_id">
+        {% for emp in empresas %}
+            <option value="{{ emp.id }}" {% if emp.id == usuario.empresa_id %}selected{% endif %}>{{ emp.nome }}</option>
+        {% endfor %}
+    </select><br>
+    <label>Role</label>
+    <select name="role">
+        <option value="usuario" {% if usuario.role == 'usuario' %}selected{% endif %}>Usuário</option>
+        <option value="gestor" {% if usuario.role == 'gestor' %}selected{% endif %}>Gestor</option>
+        <option value="superadmin" {% if usuario.role == 'superadmin' %}selected{% endif %}>Super-Admin</option>
+    </select>
+    <input type="hidden" name="token" value="{{ request.args.get('token') }}">
+    <button type="submit">Salvar</button>
+</form>


### PR DESCRIPTION
## Summary
- filter board columns and cards using `session['empresa_id']`
- list users and empresas with edit/delete options in superadmin dashboard
- add templates for editing empresa and usuario records
- render new templates from superadmin routes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a288548a4832da387784e95cdf903