### PR TITLE
Redirect to kanban after webhook login

### DIFF
--- a/app/webhook.py
+++ b/app/webhook.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, redirect, url_for
 from .models import db, Empresa, Usuario
 from .auth import login_user
 import json
@@ -45,5 +45,8 @@ def chatwoot_webhook():
         db.session.commit()
 
     login_user(usuario)
+
+    if request.method == "GET":
+        return redirect(url_for("main.index"))
 
     return jsonify({"success": True})


### PR DESCRIPTION
## Summary
- redirect authenticated users from the webhook to the Kanban board

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a3b1cb0b4832db07e258301252550