### PR TITLE
Implement redirect_next and refactor superadmin redirects

### DIFF
--- a/app/routes/superadmin.py
+++ b/app/routes/superadmin.py
@@ -22,6 +22,14 @@ def check_superadmin_token():
     _require_token()
 
 
+def redirect_next(default_endpoint):
+    """Redirect to ``next`` parameter if present else to default endpoint."""
+    next_url = request.form.get('next') or request.args.get('next')
+    if next_url:
+        return redirect(next_url)
+    return redirect(url_for(default_endpoint, token=session.get('superadmin_token')))
+
+
 @superadmin_bp.route('/')
 def dashboard():
     empresas = Empresa.query.all()
@@ -56,10 +64,7 @@ def create_empresa():
                           custom_fields=cf[:8])
         db.session.add(empresa)
         db.session.commit()
-        next_url = request.form.get('next') or request.args.get('next')
-        if next_url:
-            return redirect(next_url)
-        return redirect(url_for('superadmin.dashboard', token=session.get('superadmin_token')))
+        return redirect_next('superadmin.dashboard')
     return render_template('superadmin/create_empresa.html')
 
 
@@ -77,10 +82,7 @@ def edit_empresa(empresa_id):
             cf = []
         empresa.custom_fields = cf[:8]
         db.session.commit()
-        next_url = request.form.get('next') or request.args.get('next')
-        if next_url:
-            return redirect(next_url)
-        return redirect(url_for('superadmin.dashboard', token=session.get('superadmin_token')))
+        return redirect_next('superadmin.dashboard')
     return render_template('superadmin/edit_empresa.html', empresa=empresa)
 
 
@@ -89,10 +91,7 @@ def delete_empresa(empresa_id):
     empresa = Empresa.query.get_or_404(empresa_id)
     db.session.delete(empresa)
     db.session.commit()
-    next_url = request.form.get('next') or request.args.get('next')
-    if next_url:
-        return redirect(next_url)
-    return redirect(url_for('superadmin.dashboard', token=session.get('superadmin_token')))
+    return redirect_next('superadmin.dashboard')
 
 
 @superadmin_bp.route('/create_usuario', methods=['GET', 'POST'])
@@ -108,10 +107,7 @@ def create_usuario():
         )
         db.session.add(usuario)
         db.session.commit()
-        next_url = request.form.get('next') or request.args.get('next')
-        if next_url:
-            return redirect(next_url)
-        return redirect(url_for('superadmin.dashboard', token=session.get('superadmin_token')))
+        return redirect_next('superadmin.dashboard')
     return render_template('superadmin/create_usuario.html', empresas=empresas)
 
 
@@ -126,10 +122,7 @@ def edit_usuario(usuario_id):
         usuario.role = request.form['role']
         usuario.empresa_id = int(request.form['empresa_id'])
         db.session.commit()
-        next_url = request.form.get('next') or request.args.get('next')
-        if next_url:
-            return redirect(next_url)
-        return redirect(url_for('superadmin.dashboard', token=session.get('superadmin_token')))
+        return redirect_next('superadmin.dashboard')
     return render_template('superadmin/edit_usuario.html', usuario=usuario, empresas=empresas)
 
 
@@ -138,10 +131,7 @@ def delete_usuario(usuario_id):
     usuario = Usuario.query.get_or_404(usuario_id)
     db.session.delete(usuario)
     db.session.commit()
-    next_url = request.form.get('next') or request.args.get('next')
-    if next_url:
-        return redirect(next_url)
-    return redirect(url_for('superadmin.dashboard', token=session.get('superadmin_token')))
+    return redirect_next('superadmin.dashboard')
 
 
 @superadmin_bp.route('/create_column', methods=['GET', 'POST'])
@@ -153,10 +143,7 @@ def create_column():
         column = Column(name=name, empresa_id=empresa_id)
         db.session.add(column)
         db.session.commit()
-        next_url = request.form.get('next') or request.args.get('next')
-        if next_url:
-            return redirect(next_url)
-        return redirect(url_for('superadmin.dashboard', token=session.get('superadmin_token')))
+        return redirect_next('superadmin.dashboard')
     return render_template('superadmin/create_column.html', empresas=empresas)
 
 
@@ -168,10 +155,7 @@ def edit_column(column_id):
         column.name = request.form['name']
         column.empresa_id = int(request.form['empresa_id'])
         db.session.commit()
-        next_url = request.form.get('next') or request.args.get('next')
-        if next_url:
-            return redirect(next_url)
-        return redirect(url_for('superadmin.dashboard', token=session.get('superadmin_token')))
+        return redirect_next('superadmin.dashboard')
     return render_template('superadmin/edit_column.html', column=column, empresas=empresas)
 
 
@@ -180,7 +164,4 @@ def delete_column(column_id):
     column = Column.query.get_or_404(column_id)
     db.session.delete(column)
     db.session.commit()
-    next_url = request.form.get('next') or request.args.get('next')
-    if next_url:
-        return redirect(next_url)
-    return redirect(url_for('superadmin.dashboard', token=session.get('superadmin_token')))
+    return redirect_next('superadmin.dashboard')


### PR DESCRIPTION
## Summary
- add `redirect_next` to handle redirect with `next` parameter
- use `redirect_next` in superadmin routes

## Testing
- `python -m py_compile run.py app/*.py app/routes/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6880dc9fe868832d88e54a13d9a762dc