### PR TITLE
Allow gestores to change vendedores

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -107,7 +107,7 @@
               <div class="mb-3">
                   <label for="modalCardVendedor" class="form-label">Vendedor</label>
                   <select id="modalCardVendedor" name="vendedor_id" class="form-select">
-                      {% for usuario in g.user.empresa.usuarios %}
+                      {% for usuario in usuarios %}
                       <option value="{{ usuario.id }}" {% if usuario.id == g.user.id %}selected{% endif %}>{{ usuario.user_name }}</option>
                       {% endfor %}
                   </select>
@@ -189,7 +189,7 @@
             <div class="mb-3">
               <label for="modalAddCardVendedor" class="form-label">Vendedor</label>
               <select id="modalAddCardVendedor" name="vendedor_id" class="form-select">
-                {% for usuario in g.user.empresa.usuarios %}
+                {% for usuario in usuarios %}
                 <option value="{{ usuario.id }}" {% if usuario.id == g.user.id %}selected{% endif %}>{{ usuario.user_name }}</option>
                 {% endfor %}
               </select>


### PR DESCRIPTION
## Summary
- let gestores set `vendedor_id` when creating/editing cards
- pass company users list to the board template
- update vendor selects in the template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880f020fe40832dbfca847c3cf77124