### PR TITLE
Filter cards by user role

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -29,6 +29,16 @@ def build_custom_data(form):
 def index():
     empresa_id = session.get('empresa_id', g.user.empresa_id)
     columns = Column.query.filter_by(empresa_id=empresa_id).all()
+
+    # Filter cards for regular users so they only see their own
+    for column in columns:
+        if g.user.role == 'user':
+            column.filtered_cards = [
+                card for card in column.cards if card.vendedor_id == g.user.id
+            ]
+        else:
+            column.filtered_cards = list(column.cards)
+
     # Definições de campos customizados (JSON) por empresa
     custom_fields = g.user.empresa.custom_fields
     usuarios = g.user.empresa.usuarios

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -61,7 +61,7 @@
                 </span>
             </div>
             <div class="kanban-cards" id="column-{{ column.id }}">
-                {% for card in column.cards %}
+                {% for card in column.filtered_cards %}
                     <div class="kanban-card"
                      draggable="true"
                      data-card-id="{{ card.id }}"


### PR DESCRIPTION
## Summary
- filter cards in `index()` to only show cards for logged in user when role is `user`
- loop through these filtered cards in the template

## Testing
- `python -m py_compile app/routes/main.py`
- `python -m py_compile run.py`

------
https://chatgpt.com/codex/tasks/task_e_6880f11fec38832da933a8906bccd5e1