### PR TITLE
Replace usuario references with vendedor

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -15,7 +15,7 @@ def login_page():
 
 def login_user(usuario: Usuario) -> None:
     """Persist logged in user info in the session."""
-    session['usuario_id'] = usuario.id
+    session['vendedor_id'] = usuario.id
     session['empresa_id'] = usuario.empresa_id
     g.user = usuario
 
@@ -29,7 +29,7 @@ def logout_user() -> None:
 @auth_bp.before_app_request
 def load_logged_in_user():
     """Load user from the session and store in ``g.user``."""
-    user_id = session.get('usuario_id')
+    user_id = session.get('vendedor_id')
     if user_id is None:
         g.user = None
     else:

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -41,12 +41,12 @@ def index():
 
     # Definições de campos customizados (JSON) por empresa
     custom_fields = g.user.empresa.custom_fields
-    usuarios = g.user.empresa.usuarios
+    vendedores = g.user.empresa.usuarios
     return render_template(
         'index.html',
         columns=columns,
         custom_fields=custom_fields,
-        usuarios=usuarios,
+        vendedores=vendedores,
     )
 
 # Column CRUD

--- a/app/routes/superadmin.py
+++ b/app/routes/superadmin.py
@@ -39,12 +39,12 @@ def dashboard():
 @superadmin_bp.route('/empresa/<int:empresa_id>')
 def empresa_detail(empresa_id):
     empresa = Empresa.query.get_or_404(empresa_id)
-    usuarios = Usuario.query.filter_by(empresa_id=empresa_id).all()
+    vendedores = Usuario.query.filter_by(empresa_id=empresa_id).all()
     columns = Column.query.filter_by(empresa_id=empresa_id).all()
     return render_template(
         'superadmin/empresa_detail.html',
         empresa=empresa,
-        usuarios=usuarios,
+        vendedores=vendedores,
         columns=columns,
     )
 
@@ -94,8 +94,8 @@ def delete_empresa(empresa_id):
     return redirect_next('superadmin.dashboard')
 
 
-@superadmin_bp.route('/create_usuario', methods=['GET', 'POST'])
-def create_usuario():
+@superadmin_bp.route('/create_vendedor', methods=['GET', 'POST'])
+def create_vendedor():
     empresas = Empresa.query.all()
     if request.method == 'POST':
         usuario = Usuario(
@@ -108,12 +108,12 @@ def create_usuario():
         db.session.add(usuario)
         db.session.commit()
         return redirect_next('superadmin.dashboard')
-    return render_template('superadmin/create_usuario.html', empresas=empresas)
+    return render_template('superadmin/create_vendedor.html', empresas=empresas)
 
 
-@superadmin_bp.route('/edit_usuario/<int:usuario_id>', methods=['GET', 'POST'])
-def edit_usuario(usuario_id):
-    usuario = Usuario.query.get_or_404(usuario_id)
+@superadmin_bp.route('/edit_vendedor/<int:vendedor_id>', methods=['GET', 'POST'])
+def edit_vendedor(vendedor_id):
+    usuario = Usuario.query.get_or_404(vendedor_id)
     empresas = Empresa.query.all()
     if request.method == 'POST':
         usuario.user_id = request.form['user_id']
@@ -123,12 +123,12 @@ def edit_usuario(usuario_id):
         usuario.empresa_id = int(request.form['empresa_id'])
         db.session.commit()
         return redirect_next('superadmin.dashboard')
-    return render_template('superadmin/edit_usuario.html', usuario=usuario, empresas=empresas)
+    return render_template('superadmin/edit_vendedor.html', usuario=usuario, empresas=empresas)
 
 
-@superadmin_bp.route('/delete_usuario/<int:usuario_id>', methods=['POST'])
-def delete_usuario(usuario_id):
-    usuario = Usuario.query.get_or_404(usuario_id)
+@superadmin_bp.route('/delete_vendedor/<int:vendedor_id>', methods=['POST'])
+def delete_vendedor(vendedor_id):
+    usuario = Usuario.query.get_or_404(vendedor_id)
     db.session.delete(usuario)
     db.session.commit()
     return redirect_next('superadmin.dashboard')

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -107,8 +107,8 @@
               <div class="mb-3">
                   <label for="modalCardVendedor" class="form-label">Vendedor</label>
                   <select id="modalCardVendedor" name="vendedor_id" class="form-select">
-                      {% for usuario in usuarios %}
-                      <option value="{{ usuario.id }}" {% if usuario.id == g.user.id %}selected{% endif %}>{{ usuario.user_name }}</option>
+                      {% for vendedor in vendedores %}
+                      <option value="{{ vendedor.id }}" {% if vendedor.id == g.user.id %}selected{% endif %}>{{ vendedor.user_name }}</option>
                       {% endfor %}
                   </select>
               </div>
@@ -189,8 +189,8 @@
             <div class="mb-3">
               <label for="modalAddCardVendedor" class="form-label">Vendedor</label>
               <select id="modalAddCardVendedor" name="vendedor_id" class="form-select">
-                {% for usuario in usuarios %}
-                <option value="{{ usuario.id }}" {% if usuario.id == g.user.id %}selected{% endif %}>{{ usuario.user_name }}</option>
+                {% for vendedor in vendedores %}
+                <option value="{{ vendedor.id }}" {% if vendedor.id == g.user.id %}selected{% endif %}>{{ vendedor.user_name }}</option>
                 {% endfor %}
               </select>
             </div>

--- a/app/templates/superadmin/create_vendedor.html
+++ b/app/templates/superadmin/create_vendedor.html
@@ -1,7 +1,7 @@
 {% extends 'superadmin/layout.html' %}
-{% block title %}Criar Usuário/Gestor{% endblock %}
+{% block title %}Criar Vendedor/Gestor{% endblock %}
 {% block content %}
-<h2>Criar Usuário/Gestor</h2>
+<h2>Criar Vendedor/Gestor</h2>
 <form method="post">
     <label>User ID</label><input type="text" name="user_id"><br>
     <label>User Email</label><input type="email" name="user_email"><br>

--- a/app/templates/superadmin/edit_vendedor.html
+++ b/app/templates/superadmin/edit_vendedor.html
@@ -1,7 +1,7 @@
 {% extends 'superadmin/layout.html' %}
-{% block title %}Editar Usuário/Gestor{% endblock %}
+{% block title %}Editar Vendedor/Gestor{% endblock %}
 {% block content %}
-<h2>Editar Usuário/Gestor</h2>
+<h2>Editar Vendedor/Gestor</h2>
 <form method="post">
     <label>User ID</label><input type="text" name="user_id" value="{{ usuario.user_id }}"><br>
     <label>User Email</label><input type="email" name="user_email" value="{{ usuario.user_email }}"><br>

--- a/app/templates/superadmin/empresa_detail.html
+++ b/app/templates/superadmin/empresa_detail.html
@@ -4,17 +4,17 @@
 <h2>{{ empresa.nome }}</h2>
 <p>Account ID: {{ empresa.account_id }}</p>
 <div class="mb-3">
-  <a href="{{ url_for('superadmin.create_usuario', token=session['superadmin_token'], empresa_id=empresa.id, next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" class="btn btn-outline-secondary btn-sm">Novo Usuário/Gestor</a>
+  <a href="{{ url_for('superadmin.create_vendedor', token=session['superadmin_token'], empresa_id=empresa.id, next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" class="btn btn-outline-secondary btn-sm">Novo Vendedor/Gestor</a>
   <a href="{{ url_for('superadmin.create_column', token=session['superadmin_token'], empresa_id=empresa.id, next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" class="btn btn-outline-secondary btn-sm">Nova Coluna</a>
 </div>
-<h3>Usuários</h3>
+<h3>Vendedores</h3>
 <ul>
-  {% for usr in usuarios %}
+  {% for usr in vendedores %}
   <li class="d-flex justify-content-between align-items-center">
     <span>{{ usr.user_name }} - {{ usr.user_email }}</span>
     <div>
-      <a href="{{ url_for('superadmin.edit_usuario', usuario_id=usr.id, token=session['superadmin_token'], next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" class="btn btn-outline-primary btn-sm">Editar</a>
-      <form method="post" action="{{ url_for('superadmin.delete_usuario', usuario_id=usr.id, token=session['superadmin_token']) }}" class="d-inline">
+      <a href="{{ url_for('superadmin.edit_vendedor', vendedor_id=usr.id, token=session['superadmin_token'], next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" class="btn btn-outline-primary btn-sm">Editar</a>
+      <form method="post" action="{{ url_for('superadmin.delete_vendedor', vendedor_id=usr.id, token=session['superadmin_token']) }}" class="d-inline">
         <input type="hidden" name="next" value="{{ url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token']) }}">
         <button type="submit" class="btn btn-outline-danger btn-sm">Deletar</button>
       </form>


### PR DESCRIPTION
## Summary
- update session and template variables from usuario to vendedor
- rename user management routes to use vendedor terminology
- adjust templates for new vendedor naming

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880f1eac42c832d8c71bfe19e41ed91