### PR TITLE
Fix vendor relationship and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This project is a simple Kanban board application.
 
+Each card may store up to eight **custom fields** defined by the company.  In
+addition the following fixed fields are available:
+
+* **Título** – basic title of the card
+* **Valor negociado** – numeric value
+* **Vendedor** – user responsible for the card
+
+Regular users only see cards where they are set as the vendor.  Users with the
+`gestor` role can access all cards for their company.
+
 ## Database migrations
 
 The project uses **Flask-Migrate** to manage database schema changes.

--- a/app/models.py
+++ b/app/models.py
@@ -24,7 +24,7 @@ class Usuario(db.Model):
     role = db.Column(db.String(50), nullable=False)
     empresa_id = db.Column(db.Integer, db.ForeignKey('empresas.id'), nullable=False)
 
-    cards_vendedor = db.relationship('Card', backref='vendedor', lazy=True)
+    cards_vendedor = db.relationship('Card', back_populates='vendedor', lazy=True)
 
 
 class Column(db.Model):
@@ -45,7 +45,7 @@ class Card(db.Model):
     valor_negociado = db.Column(db.Float)
     column_id = db.Column(db.Integer, db.ForeignKey('columns.id'), nullable=False)
     vendedor_id = db.Column(db.Integer, db.ForeignKey('usuarios.id'))
-    vendedor = db.relationship('Usuario', backref='cards_vendedor')
+    vendedor = db.relationship('Usuario', back_populates='cards_vendedor')
     # dados customizáveis do card conforme definições em Empresa.custom_fields
     custom_data = db.Column(db.JSON, nullable=False, default=dict)
 


### PR DESCRIPTION
## Summary
- fix conflicting backrefs by using `back_populates`
- document Valor negociado and Vendedor fields

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880e5e7ef78832d85bc0a80a74e7936