### PR TITLE
Show card totals per column

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -13,3 +13,8 @@
     box-shadow: 0 6px 18px #0003;
     background: #e5eefe;
 }
+
+/* Align badge with column name */
+.kanban-header .badge {
+    vertical-align: middle;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -53,6 +53,9 @@
             <div class="kanban-header d-flex align-items-center justify-content-between mb-2">
                 <span class="fw-bold fs-5">
                     {{ column.name }}
+                    <span class="ms-1 badge bg-secondary">
+                        {{ column.cards_count }} • {{ column.valor_total|brl }}
+                    </span>
                     {% if g.user.role == 'superadmin' %}
                     <a href="#" class="ms-2" onclick="openEditColumnModal({{ column.id }}, '{{ column.name|tojson }}'); return false;" title="Editar coluna">
                         <i class="fa-regular fa-pen-to-square" style="font-size:1.0em;"></i>


### PR DESCRIPTION
## Summary
- display count and sum in each column header
- align the badge with the column title

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880fdb4ab3c832dae20ccd3d4c23dc4