### PR TITLE
Add dark mode field

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -12,6 +12,7 @@ class Empresa(db.Model):
     usuarios = db.relationship('Usuario', backref='empresa', cascade='all, delete', lazy=True)
     # campos customizáveis para cards: lista de definições {name, type}, até 8 itens
     custom_fields = db.Column(db.JSON, nullable=False, default=list)
+    dark_mode = db.Column(db.Boolean, nullable=False, default=False)
 
 
 class Usuario(db.Model):

--- a/migrations/versions/0002_add_dark_mode_to_empresa.py
+++ b/migrations/versions/0002_add_dark_mode_to_empresa.py
@@ -1,0 +1,18 @@
+"""Add dark_mode to Empresa
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2024-01-01 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('empresas', sa.Column('dark_mode', sa.Boolean(), nullable=False, server_default=sa.text('0')))
+    op.alter_column('empresas', 'dark_mode', server_default=None)
+
+
+def downgrade():
+    op.drop_column('empresas', 'dark_mode')
+


### PR DESCRIPTION
## Summary
- add `dark_mode` boolean column to `Empresa`
- create Alembic migration for this new field

## Testing
- `flask --app run.py db migrate -m "add dark_mode to empresa"` *(fails: command not found)*
- `flask --app run.py db upgrade` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688105d868dc832da8ab73a8dcef77a3