### PR TITLE
Add theme toggle route and button

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -179,3 +179,13 @@ def api_move_card():
     card.column_id = new_column_id
     db.session.commit()
     return jsonify({'success': True})
+
+
+@main.route('/toggle_theme', methods=['POST'])
+@login_required
+def toggle_theme():
+    """Flip the dark_mode setting for the logged user's company."""
+    empresa = g.user.empresa
+    empresa.dark_mode = not empresa.dark_mode
+    db.session.commit()
+    return jsonify({'success': True, 'dark_mode': empresa.dark_mode})

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -42,6 +42,11 @@
 <body>
 <div class="container py-4">
     <h2 class="mb-4 text-center">Kanban Board</h2>
+    <div class="mb-3 text-end">
+        <form action="{{ url_for('main.toggle_theme') }}" method="post">
+            <button type="submit" class="btn btn-outline-secondary">Modo Escuro/Claro</button>
+        </form>
+    </div>
     {% if g.user.role == 'superadmin' %}
     <div class="mb-4 text-end">
         <a href="{{ url_for('superadmin.dashboard') }}" class="btn btn-primary">Painel Super-Admin</a>


### PR DESCRIPTION
## Summary
- add `/toggle_theme` route to flip company dark mode
- expose theme toggle button on the main index page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6881078f8498832d825cd50863826e90