### PR TITLE
Add dark mode css

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -18,3 +18,22 @@
 .kanban-header .badge {
     vertical-align: middle;
 }
+
+/* Dark mode overrides */
+.dark-mode body {
+    background: #323232;
+    color: #fff;
+}
+.dark-mode .kanban-column {
+    background: #181818;
+}
+.dark-mode .kanban-card {
+    background: linear-gradient(135deg, #3a3a3a 80%, #2a2a2a 100%);
+    color: #fff;
+}
+.dark-mode .kanban-card:active {
+    background: #444;
+}
+.dark-mode .kanban-card .card-desc {
+    color: #fff;
+}


### PR DESCRIPTION
## Summary
- add a `.dark-mode` section to style overrides for dark theme

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688115a0f8c0832d9d7d9ace72dab7c3