### PR TITLE
Add Font Awesome link to templates

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,6 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Kanban Board</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/kanban.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>

--- a/app/templates/superadmin/layout.html
+++ b/app/templates/superadmin/layout.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Painel Super-Admin{% endblock %}</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/superadmin.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/kanban.css') }}">


### PR DESCRIPTION
## Summary
- load Font Awesome in the main page
- load Font Awesome in superadmin layout

## Testing
- `python -m py_compile run.py app/**/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68811e916f28832db591f4a7de5b97a1