### PR TITLE
Remove edit icon from column headers

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -34,9 +34,6 @@
                         {{ column.cards_count }} • {{ column.valor_total|brl }}
                     </span>
                     {% if g.user.role == 'superadmin' %}
-                    <a href="#" class="ms-2" onclick="openEditColumnModal({{ column.id }}, '{{ column.name|tojson }}'); return false;" title="Editar coluna">
-                        <i class="fa-regular fa-pen-to-square" style="font-size:1.0em;"></i>
-                    </a>
                     {% endif %}
                 </span>
             </div>


### PR DESCRIPTION
## Summary
- delete edit column link in Kanban headers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68812efee6fc832db582a18f372a1079