### PR TITLE
Refine header buttons

### DIFF
--- a/app/static/js/kanban.js
+++ b/app/static/js/kanban.js
@@ -53,6 +53,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 .then(data => {
                     if (data.success) {
                         document.body.classList.toggle('dark-mode', data.dark_mode);
+                        const icon = toggleForm.querySelector('i');
+                        if (icon) {
+                            icon.classList.toggle('fa-sun', data.dark_mode);
+                            icon.classList.toggle('fa-moon', !data.dark_mode);
+                        }
                     } else {
                         location.reload();
                     }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,18 +12,19 @@
 {% set dark = g.user.empresa.dark_mode %}
 <body class="{{ 'dark-mode' if dark else '' }}" data-user-id="{{ g.user.id }}">
 <div class="container py-4">
-    <div class="mb-3 text-end">
+    <header class="d-flex justify-content-end gap-2 mb-4">
         <form id="toggleThemeForm" action="{{ url_for('main.toggle_theme') }}" method="post">
             <button type="submit" class="btn btn-outline-secondary py-2 px-3">
-                <i class="fa-regular fa-moon me-1"></i>Modo Escuro/Claro
+                <i class="fa-regular {{ 'fa-sun' if dark else 'fa-moon' }}"></i>
             </button>
         </form>
-    </div>
-    {% if g.user.role == 'superadmin' %}
-    <div class="mb-4 text-end">
+        <button type="button" class="btn btn-success py-2 px-3" onclick="openAddCardModal({{ columns[0].id }}); return false;">
+            <i class="fa-solid fa-plus me-1"></i>Adicionar Card
+        </button>
+        {% if g.user.role == 'superadmin' %}
         <a href="{{ url_for('superadmin.dashboard') }}" class="btn btn-primary py-2 px-3">Painel Super-Admin</a>
-    </div>
-    {% endif %}
+        {% endif %}
+    </header>
     <div class="kanban-board row flex-wrap g-3">
         {% for column in columns %}
         <div class="kanban-column col-12 col-sm-6 col-md-4 col-lg-3" data-column-id="{{ column.id }}">


### PR DESCRIPTION
## Summary
- streamline the kanban board header
- show theme icon only and swap based on mode
- add a global "Adicionar Card" shortcut
- display Super-Admin link inside the header
- update JS to toggle icon on theme change

## Testing
- `pytest -q` *(no tests found)*
- `python -m pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6881314c04a4832d9d66383ce1b1ba2a