### PR TITLE
Update add card modal to use dropdown

### DIFF
--- a/app/static/js/kanban.js
+++ b/app/static/js/kanban.js
@@ -13,8 +13,12 @@ function openEditColumnModal(columnId, columnName) {
 }
 
 function openAddCardModal(columnId) {
-    document.getElementById('modalAddCardColumnId').value = columnId;
-    document.getElementById('addCardForm').action = "/add_card/" + columnId;
+    const select = document.getElementById('addCardColumnSelect');
+    if (select) {
+        select.value = columnId;
+    }
+    const form = document.getElementById('addCardForm');
+    form.action = "/add_card/" + columnId;
     document.getElementById('modalAddCardTitle').value = '';
     document.getElementById('modalAddCardValor').value = '';
     document.getElementById('modalAddCardVendedor').value = currentUserId;
@@ -63,6 +67,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                 })
                 .catch(() => location.reload());
+        });
+    }
+
+    const addCardColumnSelect = document.getElementById('addCardColumnSelect');
+    const addCardForm = document.getElementById('addCardForm');
+    if (addCardColumnSelect && addCardForm) {
+        addCardColumnSelect.addEventListener('change', () => {
+            addCardForm.action = "/add_card/" + addCardColumnSelect.value;
         });
     }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -55,9 +55,6 @@
                 </div>
                 {% endfor %}
             </div>
-            <button class="btn btn-success btn-sm w-100 mt-2" onclick="openAddCardModal({{ column.id }}); return false;">
-                <i class="fa-solid fa-plus"></i> Adicionar Card
-            </button>
         </div>
         {% endfor %}
     </div>
@@ -159,7 +156,14 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
           </div>
           <div class="modal-body">
-            <input type="hidden" name="column_id" id="modalAddCardColumnId">
+            <div class="mb-3">
+              <label for="addCardColumnSelect" class="form-label">Coluna</label>
+              <select id="addCardColumnSelect" class="form-select">
+                {% for col in columns %}
+                  <option value="{{ col.id }}">{{ col.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
             <div class="mb-3">
               <label for="modalAddCardTitle" class="form-label">Título</label>
               <input type="text" class="form-control" id="modalAddCardTitle" name="title" required>


### PR DESCRIPTION
## Summary
- drop per-column "Adicionar Card" button
- swap hidden column id for a dropdown in Add Card modal
- update JS to sync the dropdown with modal and form action

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ❌ `pip install -q -r requirements.txt` *(failed: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688137bb5778832d86875809def1ffb9