### PR TITLE
Fix card editing to retain custom data

### DIFF
--- a/app/static/js/kanban.js
+++ b/app/static/js/kanban.js
@@ -30,12 +30,36 @@ function openEditModal(cardDiv) {
     const title = cardDiv.getAttribute('data-title');
     const valor = cardDiv.getAttribute('data-valor') || '';
     const vendedor = cardDiv.getAttribute('data-vendedor-id') || '';
+    const customRaw = cardDiv.getAttribute('data-custom') || '{}';
+    let customData = {};
+    try {
+        customData = JSON.parse(customRaw);
+    } catch (e) {
+        customData = {};
+    }
 
     document.getElementById('modalCardId').value = cardId;
     document.getElementById('modalCardTitle').value = title;
     document.getElementById('modalCardValor').value = valor;
     document.getElementById('modalCardVendedor').value = vendedor;
     document.getElementById('editCardForm').action = "/edit_card/" + cardId;
+
+    // Pre-fill custom field inputs
+    document.querySelectorAll('#editCardModal [name^="custom_"]').forEach(input => {
+        const key = input.name.replace('custom_', '');
+        const val = customData[key];
+        if (input.type === 'checkbox') {
+            input.checked = Boolean(val);
+        } else if (input.type === 'number') {
+            if (val !== undefined && val !== null) {
+                input.value = val;
+            } else {
+                input.value = '';
+            }
+        } else {
+            input.value = val !== undefined && val !== null ? val : '';
+        }
+    });
 
     // Handler delete button
     document.getElementById('deleteCardBtn').onclick = function() {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -47,6 +47,7 @@
                      data-valor="{{ card.valor_negociado }}"
                      data-vendedor-id="{{ card.vendedor_id }}"
                      data-column-id="{{ column.id }}"
+                     data-custom='{{ card.custom_data | tojson }}'
                      onclick="openEditModal(this)">
                     <div class="card-title">{{ card.title }}</div>
                     <div class="card-desc">


### PR DESCRIPTION
## Summary
- embed each card's `custom_data` JSON in `index.html`
- parse `data-custom` in `openEditModal` and fill custom fields

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6882226d4bb8832d87940ed45542e625