### PR TITLE
Validate custom field definitions

### DIFF
--- a/tests/test_custom_fields.py
+++ b/tests/test_custom_fields.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app.routes.superadmin import parse_custom_fields, CustomFieldError
+
+
+def test_parse_valid_definition():
+    raw = '[{"name": "Status", "type": "select", "options": ["Novo"]}, {"name": "Obs", "type": "text"}]'
+    result = parse_custom_fields(raw)
+    assert result == [
+        {"name": "Status", "type": "select", "options": ["Novo"]},
+        {"name": "Obs", "type": "text"},
+    ]
+
+
+@pytest.mark.parametrize("raw", [
+    'not json',
+    '{}',
+    '[{"type": "text"}]',
+    '[{"name": "x"}]',
+    '[{"name": "x", "type": "select"}]',
+    '[{"name": "x", "type": "select", "options": []}]',
+])
+def test_parse_invalid_definition(raw):
+    with pytest.raises(CustomFieldError):
+        parse_custom_fields(raw)
+


### PR DESCRIPTION
## Summary
- enforce stricter validation for custom field definitions
- handle errors when creating/editing `Empresa`
- add unit tests for valid and invalid custom fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement blinker==1.9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6882250310f0832d9e0fdc33e9c9225d