### PR TITLE
Fix custom field modal handling

### DIFF
--- a/app/static/js/kanban.js
+++ b/app/static/js/kanban.js
@@ -22,6 +22,13 @@ function openAddCardModal(columnId) {
     document.getElementById('modalAddCardTitle').value = '';
     document.getElementById('modalAddCardValor').value = '';
     document.getElementById('modalAddCardVendedor').value = currentUserId;
+    document.querySelectorAll('#addCardModal [name^="custom_"]').forEach(input => {
+        if (input.type === 'checkbox') {
+            input.checked = false;
+        } else {
+            input.value = '';
+        }
+    });
     new bootstrap.Modal(document.getElementById('addCardModal')).show();
 }
 
@@ -50,12 +57,6 @@ function openEditModal(cardDiv) {
         const val = customData[key];
         if (input.type === 'checkbox') {
             input.checked = Boolean(val);
-        } else if (input.type === 'number') {
-            if (val !== undefined && val !== null) {
-                input.value = val;
-            } else {
-                input.value = '';
-            }
         } else {
             input.value = val !== undefined && val !== null ? val : '';
         }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -90,26 +90,28 @@
               </div>
               {% for field in custom_fields %}
               <div class="mb-3">
-                  <label class="form-label">{{ field.name }}</label>
               {% if field.type == 'text' %}
-{% if card is not defined %}
-  {% set card = namespace(custom_data={}) %}
-{% endif %}
-<input type="text" name="custom_{{ field.name }}" class="form-control" value="{{ card.custom_data[field.name]|default('') }}">
-                  {% elif field.type == 'number' %}
-                  <input type="number" step="0.01" name="custom_{{ field.name }}" class="form-control" value="{{ card.custom_data[field.name]|default(0) }}">
-                  {% elif field.type == 'boolean' %}
-                  <div class="form-check">
-                    <input class="form-check-input" type="checkbox" name="custom_{{ field.name }}" id="edit_custom_{{ loop.index }}" {% if card.custom_data[field.name] %}checked{% endif %}>
-                    <label class="form-check-label" for="edit_custom_{{ loop.index }}">{{ field.name }}</label>
-                  </div>
-                  {% elif field.type == 'select' %}
-                  <select name="custom_{{ field.name }}" class="form-select">
-                    {% for opt in field.options %}
-                      <option value="{{ opt }}" {% if card.custom_data[field.name]==opt %}selected{% endif %}>{{ opt }}</option>
-                    {% endfor %}
-                  </select>
-                  {% endif %}
+                <label class="form-label">{{ field.name }}</label>
+                {% if card is not defined %}
+                  {% set card = namespace(custom_data={}) %}
+                {% endif %}
+                <input type="text" name="custom_{{ field.name }}" class="form-control" value="{{ card.custom_data[field.name]|default('') }}">
+              {% elif field.type == 'number' %}
+                <label class="form-label">{{ field.name }}</label>
+                <input type="number" step="0.01" name="custom_{{ field.name }}" class="form-control" value="{{ card.custom_data[field.name]|default(0) }}">
+              {% elif field.type == 'boolean' %}
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="custom_{{ field.name }}" id="edit_custom_{{ loop.index }}" {% if card.custom_data[field.name] %}checked{% endif %}>
+                  <label class="form-check-label" for="edit_custom_{{ loop.index }}">{{ field.name }}</label>
+                </div>
+              {% elif field.type == 'select' %}
+                <label class="form-label">{{ field.name }}</label>
+                <select name="custom_{{ field.name }}" class="form-select">
+                  {% for opt in field.options %}
+                    <option value="{{ opt }}" {% if card.custom_data[field.name]==opt %}selected{% endif %}>{{ opt }}</option>
+                  {% endfor %}
+                </select>
+              {% endif %}
               </div>
               {% endfor %}
           </div>
@@ -189,22 +191,24 @@
             </div>
             {% for field in custom_fields %}
             <div class="mb-3">
-              <label class="form-label">{{ field.name }}</label>
               {% if field.type == 'text' %}
-              <input type="text" name="custom_{{ field.name }}" class="form-control">
+                <label class="form-label">{{ field.name }}</label>
+                <input type="text" name="custom_{{ field.name }}" class="form-control">
               {% elif field.type == 'number' %}
-              <input type="number" step="0.01" name="custom_{{ field.name }}" class="form-control">
+                <label class="form-label">{{ field.name }}</label>
+                <input type="number" step="0.01" name="custom_{{ field.name }}" class="form-control">
               {% elif field.type == 'boolean' %}
-              <div class="form-check">
-                <input class="form-check-input" type="checkbox" name="custom_{{ field.name }}" id="custom_{{ loop.index }}">
-                <label class="form-check-label" for="custom_{{ loop.index }}">{{ field.name }}</label>
-              </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="custom_{{ field.name }}" id="custom_{{ loop.index }}">
+                  <label class="form-check-label" for="custom_{{ loop.index }}">{{ field.name }}</label>
+                </div>
               {% elif field.type == 'select' %}
-              <select name="custom_{{ field.name }}" class="form-select">
-                {% for opt in field.options %}
-                <option value="{{ opt }}">{{ opt }}</option>
-                {% endfor %}
-              </select>
+                <label class="form-label">{{ field.name }}</label>
+                <select name="custom_{{ field.name }}" class="form-select">
+                  {% for opt in field.options %}
+                  <option value="{{ opt }}">{{ opt }}</option>
+                  {% endfor %}
+                </select>
               {% endif %}
             </div>
             {% endfor %}

--- a/tests/test_custom_fields.py
+++ b/tests/test_custom_fields.py
@@ -4,6 +4,10 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from app.routes.superadmin import parse_custom_fields, CustomFieldError
+from app.routes.main import build_custom_data
+from app import create_app
+from flask import g
+from types import SimpleNamespace
 
 
 def test_parse_valid_definition():
@@ -26,4 +30,31 @@ def test_parse_valid_definition():
 def test_parse_invalid_definition(raw):
     with pytest.raises(CustomFieldError):
         parse_custom_fields(raw)
+
+
+def test_build_custom_data_boolean_and_select():
+    app = create_app()
+    with app.app_context():
+        g.user = SimpleNamespace(
+            empresa=SimpleNamespace(
+                custom_fields=[
+                    {"name": "Ativo", "type": "boolean"},
+                    {"name": "Status", "type": "select", "options": ["A", "B"]},
+                ]
+            )
+        )
+        form = {"custom_Ativo": "on", "custom_Status": "B"}
+        data = build_custom_data(form)
+        assert data == {"Ativo": True, "Status": "B"}
+
+
+def test_build_custom_data_boolean_missing():
+    app = create_app()
+    with app.app_context():
+        g.user = SimpleNamespace(
+            empresa=SimpleNamespace(custom_fields=[{"name": "Flag", "type": "boolean"}])
+        )
+        form = {}
+        data = build_custom_data(form)
+        assert data == {"Flag": False}
 


### PR DESCRIPTION
## Summary
- show correct form controls for custom fields
- reset custom field inputs when adding cards
- simplify edit modal field population
- add tests for `build_custom_data`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688225c383c8832d82249df997a0f08b