### PR TITLE
Fix eye icon positioning

### DIFF
--- a/app/static/css/kanban.css
+++ b/app/static/css/kanban.css
@@ -45,6 +45,11 @@ body {
 .kanban-card:hover { box-shadow: 0 4px 18px #0003; }
 .kanban-card .card-title { font-weight: 500; margin-bottom: .4rem; }
 .kanban-card .card-desc { color: #4d5a6a; font-size: .98rem; }
+.kanban-card .eye-link {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+}
 .modal-header { background: #f0f3fc; border-bottom: none; }
 .modal-footer { border-top: none; }
 .add-form input, .add-form button { border-radius: 8px; }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -60,7 +60,7 @@
                     <div class="card-desc">
                         {{ card.valor_negociado|brl }} - {{ card.vendedor.user_name }}
                         {% if card.conversa %}
-                        <a href="{{ card.conversa }}" target="_blank" class="ms-2 text-decoration-none">
+                        <a href="{{ card.conversa }}" target="_blank" class="text-decoration-none eye-link">
                             <i class="fa-solid fa-eye text-primary"></i>
                         </a>
                         {% endif %}


### PR DESCRIPTION
## Summary
- ensure the eye icon link stays in the top-right corner of cards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68822dae1da4832da434d7cf242eebac