### PR TITLE
Enable kanban header wrapping

### DIFF
--- a/app/static/css/kanban.css
+++ b/app/static/css/kanban.css
@@ -24,6 +24,12 @@ body {
     font-size: 1.2rem;
     margin-bottom: .8rem;
     color: #0747A6;
+    flex-wrap: wrap;
+    gap: .25rem;
+}
+
+.kanban-header .column-name {
+    flex-grow: 1;
 }
 .kanban-cards {
     flex: 1;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -34,11 +34,11 @@
     <div class="kanban-board row flex-wrap g-3">
         {% for column in columns %}
         <div class="kanban-column col-12 col-sm-6 col-md-4 col-lg-3" data-column-id="{{ column.id }}">
-            <div class="kanban-header d-flex justify-content-between align-items-center mb-2">
+            <div class="kanban-header d-flex flex-wrap justify-content-between align-items-center mb-2">
                 <span class="badge bg-secondary me-2">
                     {{ column.cards_count }} • {{ column.valor_total|brl }}
                 </span>
-                <span class="fw-bold fs-5 flex-grow-1 text-end">
+                <span class="fw-bold fs-5 flex-grow-1 text-end column-name">
                     {{ column.name }}
                 </span>
                 {% if g.user.role == 'superadmin' %}


### PR DESCRIPTION
## Summary
- allow kanban headers to wrap when space is limited
- keep column name span identifiable for styling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_68823482441c832db980970ac648fba7