### PR TITLE
Enforce maximum card value

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Each card may store up to eight **custom fields** defined by the company.  In
 addition the following fixed fields are available:
 
 * **Título** – basic title of the card
-* **Valor negociado** – numeric value
+* **Valor negociado** – numeric value (máximo 9.999.999)
 * **Vendedor** – user responsible for the card
 
 ## Custom field types

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -3,6 +3,8 @@ from ..models import db, Column, Card
 from flask import jsonify
 from .auth import login_required, superadmin_required
 
+MAX_VALOR_NEGOCIADO = 9_999_999
+
 main = Blueprint('main', __name__)
 
 
@@ -100,6 +102,8 @@ def add_card(column_id):
     # Campos fixos
     title = request.form['title']
     valor_negociado = request.form.get('valor_negociado', type=float)
+    if valor_negociado is not None and valor_negociado > MAX_VALOR_NEGOCIADO:
+        return 'Valor negociado acima do permitido', 400
     conversa = request.form.get('conversa')
     vendedor_id = request.form.get('vendedor_id', type=int)
     if g.user.role != 'gestor':
@@ -129,6 +133,8 @@ def edit_card(card_id):
         return 'Acesso negado', 403
     card.title = request.form['title']
     card.valor_negociado = request.form.get('valor_negociado', type=float)
+    if card.valor_negociado is not None and card.valor_negociado > MAX_VALOR_NEGOCIADO:
+        return 'Valor negociado acima do permitido', 400
     card.conversa = request.form.get('conversa')
     if g.user.role == 'gestor':
         novo_vendedor = request.form.get('vendedor_id', type=int)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -91,7 +91,7 @@
               </div>
               <div class="mb-3">
                   <label for="modalCardValor" class="form-label">Valor negociado</label>
-                  <input type="number" step="0.01" class="form-control" id="modalCardValor" name="valor_negociado">
+                  <input type="number" step="0.01" max="9999999" class="form-control" id="modalCardValor" name="valor_negociado">
               </div>
               <div class="mb-3">
                   <label for="modalCardConversa" class="form-label">Conversa</label>
@@ -196,7 +196,7 @@
             </div>
               <div class="mb-3">
                 <label for="modalAddCardValor" class="form-label">Valor negociado</label>
-                <input type="number" step="0.01" class="form-control" id="modalAddCardValor" name="valor_negociado">
+                <input type="number" step="0.01" max="9999999" class="form-control" id="modalAddCardValor" name="valor_negociado">
               </div>
               <div class="mb-3">
                 <label for="modalAddCardConversa" class="form-label">Conversa</label>

--- a/tests/test_valor_negociado.py
+++ b/tests/test_valor_negociado.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from flask import g
+
+from app import create_app, db
+from app.models import Empresa, Usuario, Column
+from app.routes.main import MAX_VALOR_NEGOCIADO
+
+
+def setup_basic_data():
+    """Create a minimal Empresa, Usuario and Column for tests."""
+    empresa = Empresa(nome="ACME", account_id="1")
+    db.session.add(empresa)
+    db.session.commit()
+    usuario = Usuario(
+        user_id="1",
+        user_email="u@example.com",
+        user_name="U",
+        role="gestor",
+        empresa_id=empresa.id,
+    )
+    column = Column(name="Todo", empresa_id=empresa.id)
+    db.session.add_all([usuario, column])
+    db.session.commit()
+    return usuario, column
+
+
+def test_valor_negociado_limit_exceeded():
+    app = create_app()
+    with app.app_context():
+        user, column = setup_basic_data()
+        g.user = user
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['vendedor_id'] = user.id
+            sess['empresa_id'] = user.empresa_id
+        resp = client.post(
+            f'/add_card/{column.id}',
+            data={'title': 'x', 'valor_negociado': MAX_VALOR_NEGOCIADO + 1}
+        )
+        assert resp.status_code == 400
+


### PR DESCRIPTION
## Summary
- document `Valor negociado` max value
- limit card value in add/edit handlers
- restrict value input in templates
- test that server rejects values above limit

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688237ed1764832db3e1d6cb4af5c2d0