### PR TITLE
UI column header alignment

### DIFF
--- a/app/static/css/kanban.css
+++ b/app/static/css/kanban.css
@@ -29,8 +29,13 @@ body {
     font-size: 1.2rem;
     margin-bottom: .8rem;
     color: #0747A6;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: .25rem;
+}
+.kanban-header .column-name {
+    font-size: 1rem;
+    word-break: break-word;
+    min-width: 0;
 }
 .kanban-header .badge {
     white-space: normal;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -35,12 +35,12 @@
     <div class="kanban-board row flex-nowrap g-3">
         {% for column in columns %}
         <div class="kanban-column col-12 col-sm-6 col-md-4 col-lg-3" data-column-id="{{ column.id }}">
-            <div class="kanban-header d-flex flex-wrap justify-content-between align-items-center mb-2">
-                <span class="badge bg-secondary me-2">
-                    {{ column.cards_count }} • {{ column.valor_total|brl }}
-                </span>
-                <span class="fw-bold fs-5 flex-grow-1 text-end column-name">
+            <div class="kanban-header d-flex flex-nowrap justify-content-between align-items-start mb-2">
+                <span class="fw-bold fs-6 flex-grow-1 me-2 column-name">
                     {{ column.name }}
+                </span>
+                <span class="badge bg-secondary">
+                    {{ column.cards_count }} • {{ column.valor_total|brl }}
                 </span>
                 {% if g.user.role == 'superadmin' %}
                 {% endif %}


### PR DESCRIPTION
## Summary
- adjust column header layout so names appear left and counters right
- reduce column name font size and keep counters aligned

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688241071648832daee1fc10b61ac9ac