### PR TITLE
Update column width

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -34,7 +34,7 @@
     <div class="kanban-board-wrapper">
     <div class="kanban-board row flex-nowrap g-3">
         {% for column in columns %}
-        <div class="kanban-column col-12 col-sm-6 col-md-4 col-lg-3" data-column-id="{{ column.id }}">
+        <div class="kanban-column col-12 col-sm-6 col-md-4 col-lg-4" data-column-id="{{ column.id }}">
             <div class="kanban-header d-flex flex-nowrap justify-content-between align-items-start mb-2">
                 <span class="fw-bold fs-6 flex-grow-1 me-2 column-name">
                     {{ column.name }}


### PR DESCRIPTION
## Summary
- widen kanban columns slightly so they show three per row on larger screens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688243018bdc832dad698c4378057ded