### PR TITLE
Implement columns API

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -28,3 +28,4 @@ def ping():
 
 # Import additional API endpoints
 from . import cards  # noqa: E402,F401
+from . import columns  # noqa: E402,F401

--- a/api/columns.py
+++ b/api/columns.py
@@ -1,0 +1,67 @@
+from flask import request, jsonify, abort
+
+from app.models import db, Column
+
+from . import api_bp, require_superadmin_token
+
+
+def _serialize(column: Column):
+    return {
+        "id": column.id,
+        "name": column.name,
+        "empresa_id": column.empresa_id,
+    }
+
+
+@api_bp.route("/columns", methods=["GET"])
+@require_superadmin_token
+def list_columns():
+    query = Column.query
+    empresa_id = request.args.get("empresa_id", type=int)
+    if empresa_id:
+        query = query.filter(Column.empresa_id == empresa_id)
+    columns = query.all()
+    return jsonify([_serialize(c) for c in columns])
+
+
+@api_bp.route("/columns/<int:column_id>", methods=["GET"])
+@require_superadmin_token
+def get_column(column_id):
+    column = Column.query.get_or_404(column_id)
+    return jsonify(_serialize(column))
+
+
+@api_bp.route("/columns", methods=["POST"])
+@require_superadmin_token
+def create_column():
+    data = request.get_json(force=True) or {}
+    name = data.get("name")
+    empresa_id = data.get("empresa_id")
+    if not name or not empresa_id:
+        return jsonify({"error": "Missing name or empresa_id"}), 400
+    column = Column(name=name, empresa_id=empresa_id)
+    db.session.add(column)
+    db.session.commit()
+    return jsonify(_serialize(column)), 201
+
+
+@api_bp.route("/columns/<int:column_id>", methods=["PUT"])
+@require_superadmin_token
+def update_column(column_id):
+    column = Column.query.get_or_404(column_id)
+    data = request.get_json(force=True) or {}
+    name = data.get("name", column.name)
+    empresa_id = data.get("empresa_id", column.empresa_id)
+    column.name = name
+    column.empresa_id = empresa_id
+    db.session.commit()
+    return jsonify(_serialize(column))
+
+
+@api_bp.route("/columns/<int:column_id>", methods=["DELETE"])
+@require_superadmin_token
+def delete_column(column_id):
+    column = Column.query.get_or_404(column_id)
+    db.session.delete(column)
+    db.session.commit()
+    return "", 204

--- a/tests/test_api_columns.py
+++ b/tests/test_api_columns.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import Empresa
+
+
+def setup_app():
+    os.environ['SUPERADMIN_TOKEN'] = 'token'
+    app = create_app()
+    return app
+
+
+def create_empresa():
+    empresa = Empresa(nome='ACME', account_id='1')
+    db.session.add(empresa)
+    db.session.commit()
+    return empresa
+
+
+def test_columns_crud():
+    app = setup_app()
+    with app.app_context():
+        empresa = create_empresa()
+        client = app.test_client()
+        headers = {'SUPERADMIN_TOKEN': 'token'}
+
+        # Create
+        resp = client.post('/api/columns', json={'name': 'Todo', 'empresa_id': empresa.id}, headers=headers)
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data['name'] == 'Todo'
+        assert 'cards' not in data
+        column_id = data['id']
+
+        # Get
+        resp = client.get(f'/api/columns/{column_id}', headers=headers)
+        assert resp.status_code == 200
+        assert resp.get_json()['id'] == column_id
+
+        # Update
+        resp = client.put(f'/api/columns/{column_id}', json={'name': 'Doing', 'empresa_id': empresa.id}, headers=headers)
+        assert resp.status_code == 200
+        assert resp.get_json()['name'] == 'Doing'
+
+        # List
+        resp = client.get('/api/columns', headers=headers)
+        assert resp.status_code == 200
+        assert any(c['id'] == column_id for c in resp.get_json())
+
+        # Delete
+        resp = client.delete(f'/api/columns/{column_id}', headers=headers)
+        assert resp.status_code == 204
+
+        resp = client.get(f'/api/columns/{column_id}', headers=headers)
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add CRUD endpoints for columns
- wire columns module in API blueprint
- test columns CRUD API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68837408a730832d95ce8ee35e976ea2