### PR TITLE
Add custom fields API

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -29,3 +29,4 @@ def ping():
 # Import additional API endpoints
 from . import cards  # noqa: E402,F401
 from . import columns  # noqa: E402,F401
+from . import custom_fields  # noqa: E402,F401

--- a/api/custom_fields.py
+++ b/api/custom_fields.py
@@ -1,0 +1,62 @@
+import json
+from flask import request, jsonify, abort
+
+from app.models import db, Empresa
+from app.routes.superadmin import parse_custom_fields, CustomFieldError
+
+from . import api_bp, require_superadmin_token
+
+
+@api_bp.route('/custom_fields/<int:empresa_id>', methods=['GET'])
+@require_superadmin_token
+def list_custom_fields(empresa_id):
+    empresa = Empresa.query.get_or_404(empresa_id)
+    return jsonify(empresa.custom_fields)
+
+
+@api_bp.route('/custom_fields/<int:empresa_id>', methods=['POST'])
+@require_superadmin_token
+def add_custom_field(empresa_id):
+    empresa = Empresa.query.get_or_404(empresa_id)
+    data = request.get_json(force=True) or {}
+    try:
+        new_list = parse_custom_fields(
+            json.dumps(empresa.custom_fields + [data])
+        )
+    except CustomFieldError as exc:
+        return jsonify({'error': str(exc)}), 400
+    empresa.custom_fields = new_list
+    db.session.commit()
+    return jsonify(empresa.custom_fields), 201
+
+
+@api_bp.route('/custom_fields/<int:empresa_id>/<int:index>', methods=['PUT'])
+@require_superadmin_token
+def update_custom_field(empresa_id, index):
+    empresa = Empresa.query.get_or_404(empresa_id)
+    if index < 0 or index >= len(empresa.custom_fields):
+        abort(404)
+    data = request.get_json(force=True) or {}
+    fields = list(empresa.custom_fields)
+    fields[index] = data
+    try:
+        fields = parse_custom_fields(json.dumps(fields))
+    except CustomFieldError as exc:
+        return jsonify({'error': str(exc)}), 400
+    empresa.custom_fields = fields
+    db.session.commit()
+    return jsonify(empresa.custom_fields)
+
+
+@api_bp.route('/custom_fields/<int:empresa_id>/<int:index>', methods=['DELETE'])
+@require_superadmin_token
+def delete_custom_field(empresa_id, index):
+    empresa = Empresa.query.get_or_404(empresa_id)
+    if index < 0 or index >= len(empresa.custom_fields):
+        abort(404)
+    fields = list(empresa.custom_fields)
+    fields.pop(index)
+    empresa.custom_fields = fields
+    db.session.commit()
+    return '', 204
+

--- a/tests/test_api_custom_fields.py
+++ b/tests/test_api_custom_fields.py
@@ -1,0 +1,72 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import Empresa
+
+
+def setup_app():
+    os.environ['SUPERADMIN_TOKEN'] = 'token'
+    return create_app()
+
+
+def create_empresa():
+    empresa = Empresa(nome='ACME', account_id='1')
+    db.session.add(empresa)
+    db.session.commit()
+    return empresa
+
+
+def test_custom_fields_crud():
+    app = setup_app()
+    with app.app_context():
+        empresa = create_empresa()
+        client = app.test_client()
+        headers = {'SUPERADMIN_TOKEN': 'token'}
+
+        # Initially empty
+        resp = client.get(f'/api/custom_fields/{empresa.id}', headers=headers)
+        assert resp.status_code == 200
+        assert resp.get_json() == []
+
+        # Create
+        field = {'name': 'Status', 'type': 'select', 'options': ['Novo']}
+        resp = client.post(f'/api/custom_fields/{empresa.id}', json=field, headers=headers)
+        assert resp.status_code == 201
+        assert resp.get_json()[0]['name'] == 'Status'
+
+        # Update
+        new_field = {'name': 'Obs', 'type': 'text'}
+        resp = client.put(f'/api/custom_fields/{empresa.id}/0', json=new_field, headers=headers)
+        assert resp.status_code == 200
+        assert resp.get_json()[0]['name'] == 'Obs'
+
+        # Delete
+        resp = client.delete(f'/api/custom_fields/{empresa.id}/0', headers=headers)
+        assert resp.status_code == 204
+        resp = client.get(f'/api/custom_fields/{empresa.id}', headers=headers)
+        assert resp.get_json() == []
+
+
+def test_custom_fields_validation():
+    app = setup_app()
+    with app.app_context():
+        empresa = create_empresa()
+        client = app.test_client()
+        headers = {'SUPERADMIN_TOKEN': 'token'}
+
+        invalid_field = {'name': 'x'}  # Missing type
+        resp = client.post(f'/api/custom_fields/{empresa.id}', json=invalid_field, headers=headers)
+        assert resp.status_code == 400
+
+        # Create 8 valid fields
+        field = {'name': 'F', 'type': 'text'}
+        for i in range(8):
+            resp = client.post(f'/api/custom_fields/{empresa.id}', json={'name': f'f{i}', 'type': 'text'}, headers=headers)
+            assert resp.status_code == 201
+        # Attempt to add ninth
+        resp = client.post(f'/api/custom_fields/{empresa.id}', json=field, headers=headers)
+        assert resp.status_code == 400
+


### PR DESCRIPTION
## Summary
- provide REST API endpoints for `Empresa.custom_fields`
- route definitions for CRUD operations
- import new API module
- unit tests for custom fields API

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688374fb3d00832da2ef5978688ae2d9