### PR TITLE
Allow user edits/deletes for vendorless cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Example configuration:
 ```
 
 Regular users only see cards where they are set as the vendor.  Users with the
-`gestor` role can access all cards for their company.
+`gestor` role can access all cards for their company.  Cards that have no
+vendor assigned can be edited or removed by any regular user; the first edit
+will automatically set that user as the vendor.
 
 ## Front-end JavaScript
 

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -131,8 +131,11 @@ def edit_card(card_id):
     card = Card.query.get_or_404(card_id)
     if card.column.empresa_id != g.user.empresa_id:
         abort(404)
-    if g.user.role != 'gestor' and card.vendedor_id != g.user.id:
-        return 'Acesso negado', 403
+    if g.user.role != 'gestor':
+        if card.vendedor_id not in (None, g.user.id):
+            return 'Acesso negado', 403
+        if card.vendedor_id is None:
+            card.vendedor_id = g.user.id
     card.title = request.form['title']
     card.valor_negociado = request.form.get('valor_negociado', type=float)
     if card.valor_negociado is not None and card.valor_negociado > MAX_VALOR_NEGOCIADO:
@@ -155,7 +158,7 @@ def delete_card(card_id):
     card = Card.query.get_or_404(card_id)
     if card.column.empresa_id != g.user.empresa_id:
         abort(404)
-    if g.user.role != 'gestor' and card.vendedor_id != g.user.id:
+    if g.user.role != 'gestor' and card.vendedor_id not in (None, g.user.id):
         return 'Acesso negado', 403
     db.session.delete(card)
     db.session.commit()

--- a/tests/test_card_vendedor_none.py
+++ b/tests/test_card_vendedor_none.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from flask import g
+
+from app import create_app, db
+from app.models import Empresa, Usuario, Column, Card
+
+
+def setup_basic_data():
+    empresa = Empresa(nome='ACME', account_id='1')
+    db.session.add(empresa)
+    db.session.commit()
+    usuario = Usuario(user_id='1', user_email='u@example.com', user_name='U', role='user', empresa_id=empresa.id)
+    column = Column(name='Todo', empresa_id=empresa.id)
+    db.session.add_all([usuario, column])
+    db.session.commit()
+    return usuario, column
+
+
+def test_edit_and_delete_card_vendedor_none():
+    app = create_app()
+    with app.app_context():
+        user, column = setup_basic_data()
+        card_edit = Card(title='old', column_id=column.id)
+        card_delete = Card(title='del', column_id=column.id)
+        db.session.add_all([card_edit, card_delete])
+        db.session.commit()
+
+        g.user = user
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['vendedor_id'] = user.id
+            sess['empresa_id'] = user.empresa_id
+
+        # Edit card with vendedor_id None
+        resp = client.post(f'/edit_card/{card_edit.id}', data={'title': 'new'})
+        assert resp.status_code == 302
+        db.session.refresh(card_edit)
+        assert card_edit.title == 'new'
+        assert card_edit.vendedor_id == user.id
+
+        # Delete card with vendedor_id None
+        resp = client.post(f'/delete_card/{card_delete.id}')
+        assert resp.status_code == 204
+        assert Card.query.get(card_delete.id) is None


### PR DESCRIPTION
## Summary
- allow editing or deleting a card without a vendor assigned
- assign the editing user as the vendor when editing such cards
- document vendorless behavior
- test editing and deleting vendorless cards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688388cfef88832db4231d1fa61cc493