### PR TITLE
Switch superadmin actions to modals

### DIFF
--- a/app/static/js/superadmin.js
+++ b/app/static/js/superadmin.js
@@ -1,0 +1,84 @@
+// Superadmin panel modal logic
+
+function fillSelectOptions(select, options, selected) {
+    if (!select) return;
+    select.querySelectorAll('option').forEach(o => {
+        if (o.value == selected) {
+            o.selected = true;
+        } else {
+            o.selected = false;
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const editEmpresaModal = document.getElementById('editEmpresaModal');
+    if (editEmpresaModal) {
+        editEmpresaModal.addEventListener('show.bs.modal', event => {
+            const button = event.relatedTarget;
+            const id = button.getAttribute('data-id');
+            const nome = button.getAttribute('data-nome');
+            const account = button.getAttribute('data-account');
+            const dark = button.getAttribute('data-dark') === '1';
+            const custom = button.getAttribute('data-custom') || '[]';
+            const form = editEmpresaModal.querySelector('form');
+            form.action = `/superadmin/edit_empresa/${id}`;
+            form.querySelector('input[name="nome"]').value = nome;
+            form.querySelector('input[name="account_id"]').value = account;
+            form.querySelector('input[name="dark_mode"]').checked = dark;
+            form.querySelector('textarea[name="custom_fields"]').value = custom;
+        });
+    }
+
+    const editVendedorModal = document.getElementById('editVendedorModal');
+    if (editVendedorModal) {
+        editVendedorModal.addEventListener('show.bs.modal', event => {
+            const button = event.relatedTarget;
+            const id = button.getAttribute('data-id');
+            const userId = button.getAttribute('data-user');
+            const email = button.getAttribute('data-email');
+            const name = button.getAttribute('data-name');
+            const empresaId = button.getAttribute('data-empresa');
+            const role = button.getAttribute('data-role');
+            const form = editVendedorModal.querySelector('form');
+            form.action = `/superadmin/edit_vendedor/${id}`;
+            form.querySelector('input[name="user_id"]').value = userId;
+            form.querySelector('input[name="user_email"]').value = email;
+            form.querySelector('input[name="user_name"]').value = name;
+            fillSelectOptions(form.querySelector('select[name="empresa_id"]'), null, empresaId);
+            fillSelectOptions(form.querySelector('select[name="role"]'), null, role);
+        });
+    }
+
+    const createVendedorModal = document.getElementById('createVendedorModal');
+    if (createVendedorModal) {
+        createVendedorModal.addEventListener('show.bs.modal', event => {
+            const button = event.relatedTarget;
+            const empresaId = button.getAttribute('data-empresa');
+            fillSelectOptions(createVendedorModal.querySelector('select[name="empresa_id"]'), null, empresaId);
+        });
+    }
+
+    const editColumnModal = document.getElementById('editColumnModalSuper');
+    if (editColumnModal) {
+        editColumnModal.addEventListener('show.bs.modal', event => {
+            const button = event.relatedTarget;
+            const id = button.getAttribute('data-id');
+            const name = button.getAttribute('data-name');
+            const empresaId = button.getAttribute('data-empresa');
+            const form = editColumnModal.querySelector('form');
+            form.action = `/superadmin/edit_column/${id}`;
+            form.querySelector('input[name="name"]').value = name;
+            fillSelectOptions(form.querySelector('select[name="empresa_id"]'), null, empresaId);
+        });
+    }
+
+    const createColumnModal = document.getElementById('createColumnModal');
+    if (createColumnModal) {
+        createColumnModal.addEventListener('show.bs.modal', event => {
+            const button = event.relatedTarget;
+            const empresaId = button.getAttribute('data-empresa');
+            fillSelectOptions(createColumnModal.querySelector('select[name="empresa_id"]'), null, empresaId);
+        });
+    }
+});

--- a/app/templates/superadmin/dashboard.html
+++ b/app/templates/superadmin/dashboard.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h2>Painel Super-Admin</h2>
 <div class="mb-3">
-  <a href="{{ url_for('superadmin.create_empresa', token=session['superadmin_token']) }}" class="btn btn-outline-secondary btn-sm">Nova Empresa</a>
+  <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#createEmpresaModal">Nova Empresa</button>
 </div>
 <h3>Empresas</h3>
 <ul>
@@ -12,9 +12,10 @@
     <span>{{ emp.nome }} (Account ID: {{ emp.account_id }})</span>
     <div>
       <a href="{{ url_for('superadmin.empresa_detail', empresa_id=emp.id, token=session['superadmin_token']) }}" class="btn btn-outline-secondary btn-sm">Visualizar</a>
-      <a href="{{ url_for('superadmin.edit_empresa', empresa_id=emp.id, token=session['superadmin_token'], next=url_for('superadmin.dashboard', token=session['superadmin_token'])) }}" class="btn btn-outline-primary btn-sm">
+      <button type="button" class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="#editEmpresaModal"
+              data-id="{{ emp.id }}" data-nome="{{ emp.nome }}" data-account="{{ emp.account_id }}" data-dark="{{ 1 if emp.dark_mode else 0 }}" data-custom='{{ emp.custom_fields|tojson }}'>
         <i class="fa-regular fa-pen-to-square me-1"></i>Editar
-      </a>
+      </button>
       <form method="post" action="{{ url_for('superadmin.delete_empresa', empresa_id=emp.id, token=session['superadmin_token']) }}" class="d-inline">
         <input type="hidden" name="next" value="{{ url_for('superadmin.dashboard', token=session['superadmin_token']) }}">
         <button type="submit" class="btn btn-outline-danger btn-sm">
@@ -25,5 +26,76 @@
   </li>
   {% endfor %}
 </ul>
+
+<!-- Modal Criar Empresa -->
+<div class="modal fade" id="createEmpresaModal" tabindex="-1" aria-labelledby="createEmpresaModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form id="createEmpresaForm" method="post" action="{{ url_for('superadmin.create_empresa', token=session['superadmin_token']) }}">
+        <div class="modal-header">
+          <h5 class="modal-title" id="createEmpresaModalLabel">Criar Empresa</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Nome Empresa</label>
+            <input type="text" name="nome" class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Account ID</label>
+            <input type="text" name="account_id" class="form-control">
+          </div>
+          <div class="form-check form-switch mb-3">
+            <input class="form-check-input" type="checkbox" name="dark_mode" id="create_dark_mode">
+            <label class="form-check-label" for="create_dark_mode">Modo escuro</label>
+          </div>
+          <input type="hidden" name="next" value="{{ url_for('superadmin.dashboard', token=session['superadmin_token']) }}">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-primary">Criar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- Modal Editar Empresa -->
+<div class="modal fade" id="editEmpresaModal" tabindex="-1" aria-labelledby="editEmpresaModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form id="editEmpresaForm" method="post">
+        <div class="modal-header">
+          <h5 class="modal-title" id="editEmpresaModalLabel">Editar Empresa</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Nome Empresa</label>
+            <input type="text" name="nome" class="form-control" id="edit_empresa_nome">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Account ID</label>
+            <input type="text" name="account_id" class="form-control" id="edit_empresa_account_id">
+          </div>
+          <div class="form-check form-switch mb-3">
+            <input class="form-check-input" type="checkbox" name="dark_mode" id="edit_dark_mode">
+            <label class="form-check-label" for="edit_dark_mode">Modo escuro</label>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Custom Fields (JSON)</label>
+            <textarea name="custom_fields" rows="4" class="form-control" id="edit_custom_fields"></textarea>
+            <small class="text-muted">Informe uma lista JSON de até 8 objetos { "name": "...", "type": "text|number|boolean|select", "options": ["A", "B"] } para select.</small>
+          </div>
+          <input type="hidden" name="next" value="{{ url_for('superadmin.dashboard', token=session['superadmin_token']) }}">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-primary">Salvar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
 
 {% endblock %}

--- a/app/templates/superadmin/empresa_detail.html
+++ b/app/templates/superadmin/empresa_detail.html
@@ -4,8 +4,8 @@
 <h2>{{ empresa.nome }}</h2>
 <p>Account ID: {{ empresa.account_id }}</p>
 <div class="mb-3">
-  <a href="{{ url_for('superadmin.create_vendedor', token=session['superadmin_token'], empresa_id=empresa.id, next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" class="btn btn-outline-secondary btn-sm">Novo Vendedor/Gestor</a>
-  <a href="{{ url_for('superadmin.create_column', token=session['superadmin_token'], empresa_id=empresa.id, next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" class="btn btn-outline-secondary btn-sm">Nova Coluna</a>
+  <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#createVendedorModal" data-empresa="{{ empresa.id }}">Novo Vendedor/Gestor</button>
+  <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#createColumnModal" data-empresa="{{ empresa.id }}">Nova Coluna</button>
 </div>
 <h3>Vendedores</h3>
 <ul>
@@ -13,9 +13,10 @@
   <li class="d-flex justify-content-between align-items-center">
     <span>{{ usr.user_name }} - {{ usr.user_email }}</span>
     <div>
-      <a href="{{ url_for('superadmin.edit_vendedor', vendedor_id=usr.id, token=session['superadmin_token'], next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" class="btn btn-outline-primary btn-sm">
+      <button type="button" class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="#editVendedorModal"
+              data-id="{{ usr.id }}" data-user="{{ usr.user_id }}" data-email="{{ usr.user_email }}" data-name="{{ usr.user_name }}" data-empresa="{{ usr.empresa_id }}" data-role="{{ usr.role }}">
         <i class="fa-regular fa-pen-to-square me-1"></i>Editar
-      </a>
+      </button>
       <form method="post" action="{{ url_for('superadmin.delete_vendedor', vendedor_id=usr.id, token=session['superadmin_token']) }}" class="d-inline">
         <input type="hidden" name="next" value="{{ url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token']) }}">
         <button type="submit" class="btn btn-outline-danger btn-sm">
@@ -32,9 +33,10 @@
   <li class="d-flex justify-content-between align-items-center">
     <span>{{ col.name }}</span>
     <div>
-      <a href="{{ url_for('superadmin.edit_column', column_id=col.id, token=session['superadmin_token'], next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" class="btn btn-outline-primary btn-sm">
+      <button type="button" class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="#editColumnModalSuper"
+              data-id="{{ col.id }}" data-name="{{ col.name }}" data-empresa="{{ col.empresa_id }}">
         <i class="fa-regular fa-pen-to-square me-1"></i>Editar
-      </a>
+      </button>
       <form method="post" action="{{ url_for('superadmin.delete_column', column_id=col.id, token=session['superadmin_token']) }}" class="d-inline">
         <input type="hidden" name="next" value="{{ url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token']) }}">
         <button type="submit" class="btn btn-outline-danger btn-sm">
@@ -45,4 +47,163 @@
   </li>
   {% endfor %}
 </ul>
+<!-- Modal Criar Vendedor -->
+<div class="modal fade" id="createVendedorModal" tabindex="-1" aria-labelledby="createVendedorModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{{ url_for('superadmin.create_vendedor', token=session['superadmin_token'], next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" id="createVendedorForm">
+        <div class="modal-header">
+          <h5 class="modal-title" id="createVendedorModalLabel">Criar Vendedor/Gestor</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">User ID</label>
+            <input type="text" name="user_id" class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">User Email</label>
+            <input type="email" name="user_email" class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">User Name</label>
+            <input type="text" name="user_name" class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Empresa</label>
+            <select name="empresa_id" class="form-select">
+              {% for emp in empresas %}
+                <option value="{{ emp.id }}" {% if emp.id == empresa.id %}selected{% endif %}>{{ emp.nome }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Role</label>
+            <select name="role" class="form-select">
+              <option value="usuario">Usuário</option>
+              <option value="gestor">Gestor</option>
+              <option value="superadmin">Super-Admin</option>
+            </select>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-primary">Criar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- Modal Editar Vendedor -->
+<div class="modal fade" id="editVendedorModal" tabindex="-1" aria-labelledby="editVendedorModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" id="editVendedorForm">
+        <div class="modal-header">
+          <h5 class="modal-title" id="editVendedorModalLabel">Editar Vendedor/Gestor</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">User ID</label>
+            <input type="text" name="user_id" class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">User Email</label>
+            <input type="email" name="user_email" class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">User Name</label>
+            <input type="text" name="user_name" class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Empresa</label>
+            <select name="empresa_id" class="form-select">
+              {% for emp in empresas %}
+                <option value="{{ emp.id }}" {% if emp.id == empresa.id %}selected{% endif %}>{{ emp.nome }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Role</label>
+            <select name="role" class="form-select">
+              <option value="usuario">Usuário</option>
+              <option value="gestor">Gestor</option>
+              <option value="superadmin">Super-Admin</option>
+            </select>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-primary">Salvar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- Modal Criar Coluna -->
+<div class="modal fade" id="createColumnModal" tabindex="-1" aria-labelledby="createColumnModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{{ url_for('superadmin.create_column', token=session['superadmin_token'], next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" id="createColumnForm">
+        <div class="modal-header">
+          <h5 class="modal-title" id="createColumnModalLabel">Criar Coluna</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Nome da Coluna</label>
+            <input type="text" name="name" required class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Empresa</label>
+            <select name="empresa_id" class="form-select">
+              {% for emp in empresas %}
+                <option value="{{ emp.id }}" {% if emp.id == empresa.id %}selected{% endif %}>{{ emp.nome }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-primary">Criar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- Modal Editar Coluna -->
+<div class="modal fade" id="editColumnModalSuper" tabindex="-1" aria-labelledby="editColumnModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" id="editColumnFormSuper">
+        <div class="modal-header">
+          <h5 class="modal-title" id="editColumnModalLabel">Editar Coluna</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Nome da Coluna</label>
+            <input type="text" name="name" required class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Empresa</label>
+            <select name="empresa_id" class="form-select">
+              {% for emp in empresas %}
+                <option value="{{ emp.id }}" {% if emp.id == empresa.id %}selected{% endif %}>{{ emp.nome }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-primary">Salvar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/app/templates/superadmin/layout.html
+++ b/app/templates/superadmin/layout.html
@@ -17,6 +17,8 @@
 <a href="javascript:history.back()" class="btn btn-secondary back-button">
   <i class="fa fa-arrow-left"></i>
 </a>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ url_for('static', filename='js/superadmin.js') }}"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- add `superadmin.js` with modal helpers
- load Bootstrap and the new script in the superadmin layout
- replace create/edit links with modal buttons in dashboard and company detail pages
- embed modal forms directly in those templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68838ae295a8832da445f96bfb2dd121