### PR TITLE
Add placeholder for header logo

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -55,3 +55,10 @@ body.dark-mode {
     color: #fff;
     border-color: #555;
 }
+
+/* Header logo */
+.header-logo {
+    width: 40px;
+    height: 40px;
+    object-fit: contain;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,9 @@
 {% set dark = g.user.empresa.dark_mode %}
 <body class="{{ 'dark-mode' if dark else '' }}" data-user-id="{{ g.user.id }}">
 <div class="container py-4">
-    <header class="d-flex justify-content-end gap-2 mb-4">
+    <header class="d-flex justify-content-between align-items-center mb-4">
+        <img src="{{ url_for('static', filename='images/logo.png') }}" alt="Logo" class="header-logo">
+        <div class="d-flex gap-2">
         <form id="toggleThemeForm" action="{{ url_for('main.toggle_theme') }}" method="post">
             <button type="submit" class="btn btn-outline-secondary py-2 px-3">
                 <i class="fa-regular {{ 'fa-sun' if dark else 'fa-moon' }}"></i>
@@ -30,6 +32,7 @@
         {% if g.user.role == 'superadmin' %}
         <a href="{{ url_for('superadmin.dashboard') }}" class="btn btn-primary py-2 px-3">Painel Super-Admin</a>
         {% endif %}
+        </div>
     </header>
     <div class="kanban-board-wrapper">
     <div class="kanban-board row flex-nowrap g-3">


### PR DESCRIPTION
## Summary
- add placeholder header logo support on main board
- allow customizing the header logo with CSS
- create `app/static/images` for logo uploads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688398371eb8832da46baf2d0c9628f8