### PR TITLE
Add column colors

### DIFF
--- a/api/columns.py
+++ b/api/columns.py
@@ -10,6 +10,7 @@ def _serialize(column: Column):
         "id": column.id,
         "name": column.name,
         "empresa_id": column.empresa_id,
+        "color": column.color,
     }
 
 
@@ -37,9 +38,10 @@ def create_column():
     data = request.get_json(force=True) or {}
     name = data.get("name")
     empresa_id = data.get("empresa_id")
+    color = data.get("color")
     if not name or not empresa_id:
         return jsonify({"error": "Missing name or empresa_id"}), 400
-    column = Column(name=name, empresa_id=empresa_id)
+    column = Column(name=name, empresa_id=empresa_id, color=color)
     db.session.add(column)
     db.session.commit()
     return jsonify(_serialize(column)), 201
@@ -52,8 +54,10 @@ def update_column(column_id):
     data = request.get_json(force=True) or {}
     name = data.get("name", column.name)
     empresa_id = data.get("empresa_id", column.empresa_id)
+    color = data.get("color", column.color)
     column.name = name
     column.empresa_id = empresa_id
+    column.color = color
     db.session.commit()
     return jsonify(_serialize(column))
 

--- a/app/models.py
+++ b/app/models.py
@@ -37,6 +37,7 @@ class Column(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(80), nullable=False)
     empresa_id = db.Column(db.Integer, db.ForeignKey('empresas.id'), nullable=False)
+    color = db.Column(db.String(7))
 
     cards = db.relationship('Card', backref='column', cascade='all, delete', lazy=True)
 

--- a/app/routes/superadmin.py
+++ b/app/routes/superadmin.py
@@ -207,7 +207,8 @@ def create_column():
     if request.method == 'POST':
         name = request.form['name']
         empresa_id = int(request.form['empresa_id'])
-        column = Column(name=name, empresa_id=empresa_id)
+        color = request.form.get('color')
+        column = Column(name=name, empresa_id=empresa_id, color=color)
         db.session.add(column)
         db.session.commit()
         return redirect_next('superadmin.dashboard')
@@ -221,6 +222,7 @@ def edit_column(column_id):
     if request.method == 'POST':
         column.name = request.form['name']
         column.empresa_id = int(request.form['empresa_id'])
+        column.color = request.form.get('color')
         db.session.commit()
         return redirect_next('superadmin.dashboard')
     return render_template('superadmin/edit_column.html', column=column, empresas=empresas)

--- a/app/static/css/kanban.css
+++ b/app/static/css/kanban.css
@@ -58,6 +58,16 @@ body {
     border: none;
     position: relative;
 }
+.kanban-card::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 6px;
+    border-radius: 0 16px 16px 0;
+    background: var(--column-color);
+}
 .kanban-card:hover { box-shadow: 0 4px 18px #0003; }
 .kanban-card .card-title { font-weight: 500; margin-bottom: .4rem; }
 .kanban-card .card-desc { color: #4d5a6a; font-size: .98rem; }

--- a/app/static/js/superadmin.js
+++ b/app/static/js/superadmin.js
@@ -66,9 +66,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const id = button.getAttribute('data-id');
             const name = button.getAttribute('data-name');
             const empresaId = button.getAttribute('data-empresa');
+            const color = button.getAttribute('data-color') || '#000000';
             const form = editColumnModal.querySelector('form');
             form.action = `/superadmin/edit_column/${id}`;
             form.querySelector('input[name="name"]').value = name;
+            const colorInput = form.querySelector('input[name="color"]');
+            if (colorInput) colorInput.value = color;
             fillSelectOptions(form.querySelector('select[name="empresa_id"]'), null, empresaId);
         });
     }
@@ -79,6 +82,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const button = event.relatedTarget;
             const empresaId = button.getAttribute('data-empresa');
             fillSelectOptions(createColumnModal.querySelector('select[name="empresa_id"]'), null, empresaId);
+            const colorInput = createColumnModal.querySelector('input[name="color"]');
+            if (colorInput) colorInput.value = '#000000';
         });
     }
 });

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -37,7 +37,7 @@
     <div class="kanban-board-wrapper">
     <div class="kanban-board row flex-nowrap g-3">
         {% for column in columns %}
-        <div class="kanban-column col-12 col-sm-6 col-md-4 col-lg-4" data-column-id="{{ column.id }}">
+        <div class="kanban-column col-12 col-sm-6 col-md-4 col-lg-4" data-column-id="{{ column.id }}" style="--column-color: {{ column.color or '#000000' }}">
             <div class="kanban-header d-flex flex-nowrap justify-content-between align-items-start mb-2">
                 <span class="fw-bold fs-6 flex-grow-1 me-2 column-name">
                     {{ column.name }}

--- a/app/templates/superadmin/create_column.html
+++ b/app/templates/superadmin/create_column.html
@@ -8,6 +8,10 @@
         <input type="text" name="name" required class="form-control">
     </div>
     <div class="mb-3">
+        <label class="form-label">Cor</label>
+        <input type="color" name="color" value="#000000" class="form-control form-control-color">
+    </div>
+    <div class="mb-3">
         <label class="form-label">Empresa</label>
         {% set selected_emp = request.args.get('empresa_id') %}
         <select name="empresa_id" class="form-select">

--- a/app/templates/superadmin/edit_column.html
+++ b/app/templates/superadmin/edit_column.html
@@ -8,6 +8,10 @@
         <input type="text" name="name" value="{{ column.name }}" required class="form-control">
     </div>
     <div class="mb-3">
+        <label class="form-label">Cor</label>
+        <input type="color" name="color" value="{{ column.color or '#000000' }}" class="form-control form-control-color">
+    </div>
+    <div class="mb-3">
         <label class="form-label">Empresa</label>
         <select name="empresa_id" class="form-select">
             {% for emp in empresas %}

--- a/app/templates/superadmin/empresa_detail.html
+++ b/app/templates/superadmin/empresa_detail.html
@@ -34,7 +34,7 @@
     <span>{{ col.name }}</span>
     <div>
       <button type="button" class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="#editColumnModalSuper"
-              data-id="{{ col.id }}" data-name="{{ col.name }}" data-empresa="{{ col.empresa_id }}">
+              data-id="{{ col.id }}" data-name="{{ col.name }}" data-empresa="{{ col.empresa_id }}" data-color="{{ col.color }}">
         <i class="fa-regular fa-pen-to-square me-1"></i>Editar
       </button>
       <form method="post" action="{{ url_for('superadmin.delete_column', column_id=col.id, token=session['superadmin_token']) }}" class="d-inline">
@@ -158,6 +158,10 @@
             <input type="text" name="name" required class="form-control">
           </div>
           <div class="mb-3">
+            <label class="form-label">Cor</label>
+            <input type="color" name="color" value="#000000" class="form-control form-control-color">
+          </div>
+          <div class="mb-3">
             <label class="form-label">Empresa</label>
             <select name="empresa_id" class="form-select">
               {% for emp in empresas %}
@@ -188,6 +192,10 @@
           <div class="mb-3">
             <label class="form-label">Nome da Coluna</label>
             <input type="text" name="name" required class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Cor</label>
+            <input type="color" name="color" class="form-control form-control-color">
           </div>
           <div class="mb-3">
             <label class="form-label">Empresa</label>

--- a/migrations/versions/0005_add_color_to_column.py
+++ b/migrations/versions/0005_add_color_to_column.py
@@ -1,0 +1,16 @@
+"""Add color to Column
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2024-01-01 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('columns', sa.Column('color', sa.String(length=7), nullable=True))
+
+
+def downgrade():
+    op.drop_column('columns', 'color')

--- a/tests/test_api_columns.py
+++ b/tests/test_api_columns.py
@@ -28,27 +28,32 @@ def test_columns_crud():
         headers = {'Authorization': 'Bearer token'}
 
         # Create
-        resp = client.post('/api/columns', json={'name': 'Todo', 'empresa_id': empresa.id}, headers=headers)
+        resp = client.post('/api/columns', json={'name': 'Todo', 'empresa_id': empresa.id, 'color': '#ff0000'}, headers=headers)
         assert resp.status_code == 201
         data = resp.get_json()
         assert data['name'] == 'Todo'
+        assert data['color'] == '#ff0000'
         assert 'cards' not in data
         column_id = data['id']
 
         # Get
         resp = client.get(f'/api/columns/{column_id}', headers=headers)
         assert resp.status_code == 200
-        assert resp.get_json()['id'] == column_id
+        data = resp.get_json()
+        assert data['id'] == column_id
+        assert data['color'] == '#ff0000'
 
         # Update
-        resp = client.put(f'/api/columns/{column_id}', json={'name': 'Doing', 'empresa_id': empresa.id}, headers=headers)
+        resp = client.put(f'/api/columns/{column_id}', json={'name': 'Doing', 'empresa_id': empresa.id, 'color': '#00ff00'}, headers=headers)
         assert resp.status_code == 200
-        assert resp.get_json()['name'] == 'Doing'
+        data = resp.get_json()
+        assert data['name'] == 'Doing'
+        assert data['color'] == '#00ff00'
 
         # List
         resp = client.get('/api/columns', headers=headers)
         assert resp.status_code == 200
-        assert any(c['id'] == column_id for c in resp.get_json())
+        assert any(c['id'] == column_id and c['color'] == '#00ff00' for c in resp.get_json())
 
         # Delete
         resp = client.delete(f'/api/columns/{column_id}', headers=headers)


### PR DESCRIPTION
## Summary
- allow Columns to have a `color`
- expose the color via the API and accept it on create/update
- support color in the superadmin UI and JS
- display column color indicator on kanban cards
- include migration and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68876b698174832d8b1eb4db071c60f3