### PR TITLE
Add Panel model with migrations

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,7 +30,7 @@ def create_app():
     migrate.init_app(app, db)
 
     # Import models so that create_all can see them
-    from .models import Empresa, Usuario, Column, Card  # noqa: F401
+    from .models import Empresa, Usuario, Column, Card, Panel  # noqa: F401
 
     # Create database tables if they don't exist yet
     with app.app_context():

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,13 @@
 from . import db
 
 
+panel_users = db.Table(
+    "panel_users",
+    db.Column("panel_id", db.Integer, db.ForeignKey("panels.id"), primary_key=True),
+    db.Column("usuario_id", db.Integer, db.ForeignKey("usuarios.id"), primary_key=True),
+)
+
+
 class Empresa(db.Model):
     __tablename__ = 'empresas'
 
@@ -16,6 +23,17 @@ class Empresa(db.Model):
     # é necessário fornecer uma lista "options" com as opções válidas.
     custom_fields = db.Column(db.JSON, nullable=False, default=list)
     dark_mode = db.Column(db.Boolean, nullable=False, default=False)
+
+
+class Panel(db.Model):
+    __tablename__ = "panels"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), nullable=False)
+    empresa_id = db.Column(db.Integer, db.ForeignKey("empresas.id"), nullable=False)
+
+    columns = db.relationship("Column", back_populates="panel", cascade="all, delete", lazy=True)
+    usuarios = db.relationship("Usuario", secondary=panel_users, backref=db.backref("panels", lazy=True))
 
 
 class Usuario(db.Model):
@@ -37,8 +55,10 @@ class Column(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(80), nullable=False)
     empresa_id = db.Column(db.Integer, db.ForeignKey('empresas.id'), nullable=False)
+    panel_id = db.Column(db.Integer, db.ForeignKey('panels.id'))
     color = db.Column(db.String(7))
 
+    panel = db.relationship('Panel', back_populates='columns')
     cards = db.relationship('Card', backref='column', cascade='all, delete', lazy=True)
 
 

--- a/migrations/versions/0006_add_panel_model.py
+++ b/migrations/versions/0006_add_panel_model.py
@@ -1,0 +1,51 @@
+"""Add Panel model and panel_users table
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2024-01-01 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'panels',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(length=80), nullable=False),
+        sa.Column('empresa_id', sa.Integer(), nullable=False),
+    )
+    op.create_foreign_key(None, 'panels', 'empresas', ['empresa_id'], ['id'])
+
+    op.create_table(
+        'panel_users',
+        sa.Column('panel_id', sa.Integer(), nullable=False),
+        sa.Column('usuario_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['panel_id'], ['panels.id']),
+        sa.ForeignKeyConstraint(['usuario_id'], ['usuarios.id']),
+        sa.PrimaryKeyConstraint('panel_id', 'usuario_id'),
+    )
+
+    op.add_column('columns', sa.Column('panel_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(None, 'columns', 'panels', ['panel_id'], ['id'])
+
+    # create one panel per existing empresa and assign columns
+    connection = op.get_bind()
+    empresas = connection.execute(sa.text('SELECT id, nome FROM empresas')).fetchall()
+    for empresa in empresas:
+        res = connection.execute(
+            sa.text('INSERT INTO panels (name, empresa_id) VALUES (:name, :eid)'),
+            {'name': 'Default', 'eid': empresa.id},
+        )
+        panel_id = res.lastrowid
+        connection.execute(
+            sa.text('UPDATE columns SET panel_id = :pid WHERE empresa_id = :eid'),
+            {'pid': panel_id, 'eid': empresa.id},
+        )
+
+
+def downgrade():
+    op.drop_constraint(None, 'columns', type_='foreignkey')
+    op.drop_column('columns', 'panel_id')
+    op.drop_table('panel_users')
+    op.drop_table('panels')


### PR DESCRIPTION
## Summary
- create `Panel` model
- set up many-to-many relationship with `Usuario` through `panel_users`
- link `Column` to `Panel`
- include a migration that creates the new tables and migrates old data
- import Panel when creating the app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `flask --app run.py db upgrade` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688786fa642c832d8ca20eaac7ed7306