### PR TITLE
Add superadmin panel management

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -40,11 +40,13 @@ def create_app():
     from .routes.webhook import webhook_bp
     from .routes.auth import auth_bp
     from .routes.superadmin import superadmin_bp
+    from .routes.panels import panels_bp
     from api import api_bp
     app.register_blueprint(main)
     app.register_blueprint(webhook_bp)
     app.register_blueprint(auth_bp)
     app.register_blueprint(superadmin_bp)
+    app.register_blueprint(panels_bp)
     app.register_blueprint(api_bp)
 
     return app

--- a/app/models.py
+++ b/app/models.py
@@ -32,8 +32,18 @@ class Panel(db.Model):
     name = db.Column(db.String(80), nullable=False)
     empresa_id = db.Column(db.Integer, db.ForeignKey("empresas.id"), nullable=False)
 
-    columns = db.relationship("Column", back_populates="panel", cascade="all, delete", lazy=True)
-    usuarios = db.relationship("Usuario", secondary=panel_users, backref=db.backref("panels", lazy=True))
+    columns = db.relationship(
+        "Column",
+        back_populates="panel",
+        cascade="all, delete",
+        lazy=True,
+    )
+    usuarios = db.relationship(
+        "Usuario",
+        secondary=panel_users,
+        backref=db.backref("panels", lazy=True),
+    )
+    empresa = db.relationship("Empresa", backref=db.backref("panels", lazy=True))
 
 
 class Usuario(db.Model):

--- a/app/routes/panels.py
+++ b/app/routes/panels.py
@@ -1,0 +1,64 @@
+from flask import Blueprint, render_template, request, redirect, url_for, session, abort, g
+
+from ..models import db, Panel, Empresa, Usuario
+from .superadmin import _require_token, redirect_next
+
+panels_bp = Blueprint('panels', __name__, url_prefix='/superadmin')
+
+
+@panels_bp.before_request
+def check_superadmin_token():
+    if g.get('user') and g.user.role == 'superadmin':
+        return
+    _require_token()
+
+
+@panels_bp.route('/create_panel', methods=['GET', 'POST'])
+def create_panel():
+    empresas = Empresa.query.all()
+    usuarios = Usuario.query.filter(Usuario.role != 'superadmin').all()
+    if request.method == 'POST':
+        name = request.form['name']
+        empresa_id = int(request.form['empresa_id'])
+        user_ids = [int(uid) for uid in request.form.getlist('usuario_ids')]
+        panel = Panel(name=name, empresa_id=empresa_id)
+        if user_ids:
+            panel.usuarios = Usuario.query.filter(Usuario.id.in_(user_ids)).all()
+        db.session.add(panel)
+        db.session.commit()
+        return redirect_next('superadmin.dashboard')
+    empresa_id = request.args.get('empresa_id', type=int)
+    return render_template(
+        'superadmin/create_panel.html',
+        empresas=empresas,
+        usuarios=usuarios,
+        empresa_id=empresa_id,
+    )
+
+
+@panels_bp.route('/edit_panel/<int:panel_id>', methods=['GET', 'POST'])
+def edit_panel(panel_id):
+    panel = Panel.query.get_or_404(panel_id)
+    empresas = Empresa.query.all()
+    usuarios = Usuario.query.filter(Usuario.role != 'superadmin').all()
+    if request.method == 'POST':
+        panel.name = request.form['name']
+        panel.empresa_id = int(request.form['empresa_id'])
+        user_ids = [int(uid) for uid in request.form.getlist('usuario_ids')]
+        panel.usuarios = Usuario.query.filter(Usuario.id.in_(user_ids)).all()
+        db.session.commit()
+        return redirect_next('superadmin.dashboard')
+    return render_template(
+        'superadmin/edit_panel.html',
+        panel=panel,
+        empresas=empresas,
+        usuarios=usuarios,
+    )
+
+
+@panels_bp.route('/delete_panel/<int:panel_id>', methods=['POST'])
+def delete_panel(panel_id):
+    panel = Panel.query.get_or_404(panel_id)
+    db.session.delete(panel)
+    db.session.commit()
+    return redirect_next('superadmin.dashboard')

--- a/app/routes/superadmin.py
+++ b/app/routes/superadmin.py
@@ -1,7 +1,7 @@
 import os
 from flask import Blueprint, render_template, request, redirect, url_for, session, abort, g
 import json
-from ..models import db, Empresa, Usuario, Column
+from ..models import db, Empresa, Usuario, Column, Panel
 
 
 class CustomFieldError(ValueError):
@@ -95,7 +95,8 @@ def redirect_next(default_endpoint):
 @superadmin_bp.route('/')
 def dashboard():
     empresas = Empresa.query.all()
-    return render_template('superadmin/dashboard.html', empresas=empresas)
+    panels = Panel.query.all()
+    return render_template('superadmin/dashboard.html', empresas=empresas, panels=panels)
 
 
 @superadmin_bp.route('/empresa/<int:empresa_id>')
@@ -103,11 +104,13 @@ def empresa_detail(empresa_id):
     empresa = Empresa.query.get_or_404(empresa_id)
     vendedores = Usuario.query.filter_by(empresa_id=empresa_id).all()
     columns = Column.query.filter_by(empresa_id=empresa_id).all()
+    panels = Panel.query.filter_by(empresa_id=empresa_id).all()
     return render_template(
         'superadmin/empresa_detail.html',
         empresa=empresa,
         vendedores=vendedores,
         columns=columns,
+        panels=panels,
     )
 
 

--- a/app/templates/superadmin/create_panel.html
+++ b/app/templates/superadmin/create_panel.html
@@ -1,0 +1,30 @@
+{% extends 'superadmin/layout.html' %}
+{% block title %}Criar Painel{% endblock %}
+{% block content %}
+<h2>Criar Painel</h2>
+<form method="post" class="mb-4">
+    <div class="mb-3">
+        <label class="form-label">Nome do Painel</label>
+        <input type="text" name="name" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Empresa</label>
+        <select name="empresa_id" class="form-select">
+            {% for emp in empresas %}
+                <option value="{{ emp.id }}" {% if emp.id == empresa_id %}selected{% endif %}>{{ emp.nome }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Usuários</label>
+        <select name="usuario_ids" multiple class="form-select">
+            {% for usr in usuarios %}
+                <option value="{{ usr.id }}">{{ usr.user_name }} - {{ usr.user_email }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <input type="hidden" name="token" value="{{ request.args.get('token') }}">
+    <input type="hidden" name="next" value="{{ request.args.get('next') }}">
+    <button type="submit" class="btn btn-primary">Criar</button>
+</form>
+{% endblock %}

--- a/app/templates/superadmin/dashboard.html
+++ b/app/templates/superadmin/dashboard.html
@@ -27,6 +27,29 @@
   {% endfor %}
 </ul>
 
+<h3 class="mt-4">Painéis</h3>
+<div class="mb-3">
+  <a href="{{ url_for('panels.create_panel', token=session['superadmin_token']) }}" class="btn btn-outline-secondary btn-sm">Novo Painel</a>
+</div>
+<ul>
+  {% for panel in panels %}
+  <li class="d-flex justify-content-between align-items-center">
+    <span>{{ panel.name }} - {{ panel.empresa.nome }}</span>
+    <div>
+      <a href="{{ url_for('panels.edit_panel', panel_id=panel.id, token=session['superadmin_token']) }}" class="btn btn-outline-primary btn-sm">
+        <i class="fa-regular fa-pen-to-square me-1"></i>Editar
+      </a>
+      <form method="post" action="{{ url_for('panels.delete_panel', panel_id=panel.id, token=session['superadmin_token']) }}" class="d-inline">
+        <input type="hidden" name="next" value="{{ url_for('superadmin.dashboard', token=session['superadmin_token']) }}">
+        <button type="submit" class="btn btn-outline-danger btn-sm">
+          <i class="fa-solid fa-trash me-1"></i>Deletar
+        </button>
+      </form>
+    </div>
+  </li>
+  {% endfor %}
+</ul>
+
 <!-- Modal Criar Empresa -->
 <div class="modal fade" id="createEmpresaModal" tabindex="-1" aria-labelledby="createEmpresaModalLabel" aria-hidden="true">
   <div class="modal-dialog">

--- a/app/templates/superadmin/edit_panel.html
+++ b/app/templates/superadmin/edit_panel.html
@@ -1,0 +1,30 @@
+{% extends 'superadmin/layout.html' %}
+{% block title %}Editar Painel{% endblock %}
+{% block content %}
+<h2>Editar Painel</h2>
+<form method="post" class="mb-4">
+    <div class="mb-3">
+        <label class="form-label">Nome do Painel</label>
+        <input type="text" name="name" class="form-control" value="{{ panel.name }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Empresa</label>
+        <select name="empresa_id" class="form-select">
+            {% for emp in empresas %}
+                <option value="{{ emp.id }}" {% if emp.id == panel.empresa_id %}selected{% endif %}>{{ emp.nome }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Usuários</label>
+        <select name="usuario_ids" multiple class="form-select">
+            {% for usr in usuarios %}
+                <option value="{{ usr.id }}" {% if usr in panel.usuarios %}selected{% endif %}>{{ usr.user_name }} - {{ usr.user_email }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <input type="hidden" name="token" value="{{ request.args.get('token') }}">
+    <input type="hidden" name="next" value="{{ request.args.get('next') }}">
+    <button type="submit" class="btn btn-primary">Salvar</button>
+</form>
+{% endblock %}

--- a/app/templates/superadmin/empresa_detail.html
+++ b/app/templates/superadmin/empresa_detail.html
@@ -6,6 +6,7 @@
 <div class="mb-3">
   <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#createVendedorModal" data-empresa="{{ empresa.id }}">Novo Vendedor/Gestor</button>
   <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#createColumnModal" data-empresa="{{ empresa.id }}">Nova Coluna</button>
+  <a href="{{ url_for('panels.create_panel', empresa_id=empresa.id, token=session['superadmin_token'], next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" class="btn btn-outline-secondary btn-sm">Novo Painel</a>
 </div>
 <h3>Vendedores</h3>
 <ul>
@@ -18,6 +19,25 @@
         <i class="fa-regular fa-pen-to-square me-1"></i>Editar
       </button>
       <form method="post" action="{{ url_for('superadmin.delete_vendedor', vendedor_id=usr.id, token=session['superadmin_token']) }}" class="d-inline">
+        <input type="hidden" name="next" value="{{ url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token']) }}">
+        <button type="submit" class="btn btn-outline-danger btn-sm">
+          <i class="fa-solid fa-trash me-1"></i>Deletar
+        </button>
+      </form>
+    </div>
+  </li>
+  {% endfor %}
+</ul>
+<h3>Painéis</h3>
+<ul>
+  {% for panel in panels %}
+  <li class="d-flex justify-content-between align-items-center">
+    <span>{{ panel.name }}</span>
+    <div>
+      <a href="{{ url_for('panels.edit_panel', panel_id=panel.id, token=session['superadmin_token'], next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" class="btn btn-outline-primary btn-sm">
+        <i class="fa-regular fa-pen-to-square me-1"></i>Editar
+      </a>
+      <form method="post" action="{{ url_for('panels.delete_panel', panel_id=panel.id, token=session['superadmin_token']) }}" class="d-inline">
         <input type="hidden" name="next" value="{{ url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token']) }}">
         <button type="submit" class="btn btn-outline-danger btn-sm">
           <i class="fa-solid fa-trash me-1"></i>Deletar


### PR DESCRIPTION
## Summary
- allow superadmins to manage Panels
- list panels on dashboard and empresa detail pages
- add templates for panel creation and editing
- register new blueprint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68878823e45c832da08eaf3b5d9c87b5