### PR TITLE
Add panel selection form

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -81,6 +81,8 @@ def index():
         columns=columns,
         custom_fields=custom_fields,
         vendedores=vendedores,
+        panels=allowed_panels,
+        active_panel_id=panel_id,
     )
 
 # Column CRUD
@@ -233,6 +235,22 @@ def api_move_card():
     card.column_id = new_column_id
     db.session.commit()
     return jsonify({'success': True})
+
+
+@main.route('/select_panel', methods=['POST'])
+@login_required
+def select_panel():
+    """Update the selected panel in the user session."""
+    panel_id = request.form.get('panel_id', type=int)
+    empresa_id = session.get('empresa_id', g.user.empresa_id)
+    if g.user.role == 'user':
+        allowed_panels = [p for p in g.user.panels if p.empresa_id == empresa_id]
+    else:
+        allowed_panels = Panel.query.filter_by(empresa_id=empresa_id).all()
+    allowed_ids = {p.id for p in allowed_panels}
+    if panel_id in allowed_ids:
+        session['panel_id'] = panel_id
+    return redirect(url_for('main.index'))
 
 
 @main.route('/toggle_theme', methods=['POST'])

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -13,7 +13,18 @@
 <body class="{{ 'dark-mode' if dark else '' }}" data-user-id="{{ g.user.id }}">
 <div class="container py-4">
     <header class="d-flex justify-content-between align-items-center mb-4">
-        <img src="{{ url_for('static', filename='images/logo.png') }}" alt="Logo" class="header-logo">
+        <div class="d-flex align-items-center gap-3">
+            <img src="{{ url_for('static', filename='images/logo.png') }}" alt="Logo" class="header-logo">
+            {% if panels %}
+            <form method="post" action="{{ url_for('main.select_panel') }}">
+                <select name="panel_id" class="form-select" onchange="this.form.submit()">
+                    {% for panel in panels %}
+                    <option value="{{ panel.id }}" {% if panel.id == active_panel_id %}selected{% endif %}>{{ panel.name }}</option>
+                    {% endfor %}
+                </select>
+            </form>
+            {% endif %}
+        </div>
         <div class="d-flex gap-2">
         <form id="toggleThemeForm" action="{{ url_for('main.toggle_theme') }}" method="post">
             <button type="submit" class="btn btn-outline-secondary py-2 px-3">


### PR DESCRIPTION
## Summary
- expose the allowed panels to the index template
- add `/select_panel` route for changing the active panel
- show a panel dropdown in the header

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68878b49b6f8832db5446da7ffc1a576