### PR TITLE
Enforce panel permissions

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -76,3 +76,27 @@ def gestor_required(view):
 
     return role_required('gestor')(view)
 
+
+def is_panel_member(panel) -> bool:
+    """Return ``True`` if ``g.user`` is member of the given panel."""
+
+    if panel is None:
+        return False
+    return any(u.id == g.user.id for u in panel.usuarios)
+
+
+def has_panel_access(panel) -> bool:
+    """Check whether ``g.user`` may access ``panel``."""
+
+    if g.get('user') is None:
+        return False
+    if g.user.role == 'superadmin':
+        return True
+    if panel is None:
+        return False
+    if panel.empresa_id != g.user.empresa_id:
+        return False
+    if g.user.role == 'gestor':
+        return True
+    return is_panel_member(panel)
+


### PR DESCRIPTION
## Summary
- add helpers in auth to check panel access
- require panel access for column/card changes
- only allow assigning card vendors that belong to the panel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68878c55fae0832d940d6c06f0e4bdcf