### PR TITLE
Add placeholder for custom fields textareas

### DIFF
--- a/app/templates/superadmin/dashboard.html
+++ b/app/templates/superadmin/dashboard.html
@@ -107,7 +107,7 @@
           </div>
           <div class="mb-3">
             <label class="form-label">Custom Fields (JSON)</label>
-            <textarea name="custom_fields" rows="4" class="form-control" id="edit_custom_fields"></textarea>
+              <textarea name="custom_fields" rows="4" class="form-control" id="edit_custom_fields" placeholder='[{"name":"Status","type":"select","options":["A","B"]}]'></textarea>
             <small class="text-muted">Informe uma lista JSON de até 8 objetos { "name": "...", "type": "text|number|boolean|select", "options": ["A", "B"] } para select.</small>
           </div>
           <input type="hidden" name="next" value="{{ url_for('superadmin.dashboard', token=session['superadmin_token']) }}">

--- a/app/templates/superadmin/edit_empresa.html
+++ b/app/templates/superadmin/edit_empresa.html
@@ -17,7 +17,7 @@
     </div>
     <div class="mb-3">
         <label class="form-label">Custom Fields (JSON)</label>
-        <textarea name="custom_fields" rows="4" class="form-control">{{ empresa.custom_fields|tojson }}</textarea>
+        <textarea name="custom_fields" rows="4" class="form-control" placeholder='[{"name":"Status","type":"select","options":["A","B"]}]'>{{ empresa.custom_fields|tojson }}</textarea>
         <small class="text-muted">Informe uma lista JSON de até 8 objetos { "name": "...", "type": "text|number|boolean|select", "options": ["A", "B"] } para select.</small>
     </div>
     <input type="hidden" name="token" value="{{ request.args.get('token') }}">


### PR DESCRIPTION
## Summary
- show an example JSON in the custom fields textarea of edit_empresa.html
- show the same example in the dashboard edit modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6888c0faac30832d8cb8cc0e5f15a9ad