### PR TITLE
Fix create column form URL

### DIFF
--- a/app/templates/superadmin/empresa_detail.html
+++ b/app/templates/superadmin/empresa_detail.html
@@ -151,7 +151,7 @@
 <div class="modal fade" id="createColumnModal" tabindex="-1" aria-labelledby="createColumnModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
-        <form method="post" action="{{ url_for('superadmin.create_column', empresa_id=empresa.id, token=session['superadmin_token'], next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" id="createColumnForm">
+        <form method="post" action="{{ url_for('panels.create_column', empresa_id=empresa.id, token=session['superadmin_token'], next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" id="createColumnForm">
         <div class="modal-header">
           <h5 class="modal-title" id="createColumnModalLabel">Criar Coluna</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>


### PR DESCRIPTION
## Summary
- fix link for creating columns on empresa detail page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6888c5bcf1ac832da9592275ed7c8503