### PR TITLE
Implement scroll for long superadmin lists

### DIFF
--- a/app/static/css/superadmin.css
+++ b/app/static/css/superadmin.css
@@ -64,3 +64,44 @@ body.dark-mode {
     left: 20px;
     z-index: 1000;
 }
+
+/* Horizontal scroll lists */
+.scroll-area {
+    position: relative;
+}
+
+.scroll-area ul {
+    display: flex;
+    overflow-x: auto;
+    gap: 0.5rem;
+    padding: 0;
+    margin: 0;
+}
+
+.scroll-area li {
+    flex: 0 0 auto;
+    margin-bottom: 0;
+}
+
+.scroll-arrow {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 2rem;
+    height: 2rem;
+    border: none;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #e9ecef;
+    padding: 0;
+}
+
+.scroll-arrow.prev {
+    left: -1.5rem;
+}
+
+.scroll-arrow.next {
+    right: -1.5rem;
+}

--- a/app/static/js/superadmin.js
+++ b/app/static/js/superadmin.js
@@ -101,4 +101,25 @@ document.addEventListener('DOMContentLoaded', () => {
             select.addEventListener('change', updateCreateColumnAction);
         }
     }
+
+    // Convert long lists into horizontal scroll areas
+    document.querySelectorAll('.scroll-area ul').forEach(ul => {
+        if (ul.children.length > 5) {
+            const wrapper = ul.parentElement;
+            const prev = document.createElement('button');
+            prev.className = 'scroll-arrow prev btn btn-light';
+            prev.innerHTML = '<i class="fa-solid fa-chevron-left"></i>';
+            const next = document.createElement('button');
+            next.className = 'scroll-arrow next btn btn-light';
+            next.innerHTML = '<i class="fa-solid fa-chevron-right"></i>';
+            wrapper.appendChild(prev);
+            wrapper.appendChild(next);
+            prev.addEventListener('click', () => {
+                ul.scrollBy({left: -200, behavior: 'smooth'});
+            });
+            next.addEventListener('click', () => {
+                ul.scrollBy({left: 200, behavior: 'smooth'});
+            });
+        }
+    });
 });

--- a/app/templates/superadmin/dashboard.html
+++ b/app/templates/superadmin/dashboard.html
@@ -6,6 +6,7 @@
   <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#createEmpresaModal">Nova Empresa</button>
 </div>
 <h3>Empresas</h3>
+<div class="scroll-area">
 <ul>
   {% for emp in empresas %}
   <li class="d-flex justify-content-between align-items-center">
@@ -26,6 +27,7 @@
   </li>
   {% endfor %}
 </ul>
+</div>
 
 
 

--- a/app/templates/superadmin/edit_panel.html
+++ b/app/templates/superadmin/edit_panel.html
@@ -44,6 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
 <div class="mb-3">
   <a href="{{ url_for('panels.create_column', panel_id=panel.id, token=session['superadmin_token'], next=url_for('panels.edit_panel', panel_id=panel.id, token=session['superadmin_token'])) }}" class="btn btn-outline-secondary btn-sm">Nova Coluna</a>
 </div>
+<div class="scroll-area">
 <ul>
   {% for col in panel.columns %}
   <li class="d-flex justify-content-between align-items-center">
@@ -62,4 +63,5 @@ document.addEventListener('DOMContentLoaded', () => {
   </li>
   {% endfor %}
 </ul>
+</div>
 {% endblock %}

--- a/app/templates/superadmin/empresa_detail.html
+++ b/app/templates/superadmin/empresa_detail.html
@@ -9,6 +9,7 @@
   <a href="{{ url_for('panels.create_panel', empresa_id=empresa.id, token=session['superadmin_token'], next=url_for('superadmin.empresa_detail', empresa_id=empresa.id, token=session['superadmin_token'])) }}" class="btn btn-outline-secondary btn-sm">Novo Painel</a>
 </div>
 <h3>Vendedores</h3>
+<div class="scroll-area">
 <ul>
   {% for usr in vendedores %}
   <li class="d-flex justify-content-between align-items-center">
@@ -28,7 +29,9 @@
   </li>
   {% endfor %}
 </ul>
+</div>
 <h3>Painéis</h3>
+<div class="scroll-area">
 <ul>
   {% for panel in panels %}
   <li class="d-flex justify-content-between align-items-center">
@@ -45,9 +48,10 @@
       </form>
     </div>
   </li>
-  {% endfor %}
 </ul>
+</div>
 <h3>Colunas</h3>
+<div class="scroll-area">
 <ul>
   {% for col in columns %}
   <li class="d-flex justify-content-between align-items-center">
@@ -67,6 +71,7 @@
   </li>
   {% endfor %}
 </ul>
+</div>
 <!-- Modal Criar Vendedor -->
 <div class="modal fade" id="createVendedorModal" tabindex="-1" aria-labelledby="createVendedorModalLabel" aria-hidden="true">
   <div class="modal-dialog">


### PR DESCRIPTION
## Summary
- make long lists horizontally scrollable in the superadmin panel
- add arrow navigation using new JS logic
- wrap existing lists in scroll containers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6888d32c05ac832db26b85d6331e6815