### PR TITLE
Add created_at column

### DIFF
--- a/api/cards.py
+++ b/api/cards.py
@@ -38,6 +38,7 @@ def _serialize(card: Card):
         "vendedor_id": card.vendedor_id,
         "vendedor_name": card.vendedor.user_name if card.vendedor else None,
         "custom_data": card.custom_data,
+        "created_at": card.created_at.isoformat() if card.created_at else None,
     }
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from . import db
 
 
@@ -88,4 +89,5 @@ class Card(db.Model):
     vendedor = db.relationship('Usuario', back_populates='cards_vendedor')
     # dados customizáveis do card conforme definições em Empresa.custom_fields
     custom_data = db.Column(db.JSON, nullable=False, default=dict)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 

--- a/migrations/versions/0008_add_created_at_to_card.py
+++ b/migrations/versions/0008_add_created_at_to_card.py
@@ -1,0 +1,17 @@
+"""Add created_at to Card
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2024-01-01 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('cards', sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.text('(CURRENT_TIMESTAMP)')))
+    op.alter_column('cards', 'created_at', server_default=None)
+
+
+def downgrade():
+    op.drop_column('cards', 'created_at')


### PR DESCRIPTION
## Summary
- add created_at field to `Card` model
- expose created_at via API and SSE
- create Alembic migration for the new column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6888d659a994832da097129b744cd436