### PR TITLE
Add created_at display

### DIFF
--- a/app/static/css/kanban.css
+++ b/app/static/css/kanban.css
@@ -90,6 +90,11 @@ body {
     top: 0.5rem;
     right: 0.5rem;
 }
+.kanban-card .card-date {
+    font-size: .8rem;
+    color: #6c757d;
+    margin-top: .25rem;
+}
 .modal-header { background: #f0f3fc; border-bottom: none; }
 .modal-footer { border-top: none; }
 .add-form input, .add-form button { border-radius: 8px; }

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -37,6 +37,9 @@ body.dark-mode {
 .dark-mode .kanban-card .card-desc {
     color: #fff;
 }
+.dark-mode .kanban-card .card-date {
+    color: #ccc;
+}
 
 /* Dark mode modal styling */
 .dark-mode .modal-content {

--- a/app/static/js/kanban.js
+++ b/app/static/js/kanban.js
@@ -96,6 +96,12 @@ function formatBRL(value) {
     });
 }
 
+function formatDate(value) {
+    if (!value) return '';
+    const d = new Date(value);
+    return d.toLocaleDateString('pt-BR');
+}
+
 function updateColumnStats(columnEl) {
     const cards = columnEl.querySelectorAll('.kanban-card');
     let total = 0;
@@ -278,6 +284,10 @@ document.addEventListener('DOMContentLoaded', () => {
             descDiv.appendChild(link);
         }
         div.appendChild(descDiv);
+        const dateEl = document.createElement('small');
+        dateEl.className = 'card-date text-muted';
+        dateEl.textContent = `Data da Oportunidade: ${formatDate(card.created_at)}`;
+        div.appendChild(dateEl);
         return div;
     }
 
@@ -314,6 +324,15 @@ document.addEventListener('DOMContentLoaded', () => {
             link.className = 'text-decoration-none eye-link';
             link.innerHTML = '<i class="fa-solid fa-eye text-primary"></i>';
             existing.querySelector('.card-desc').appendChild(link);
+        }
+        const dateEl = existing.querySelector('.card-date');
+        if (dateEl) {
+            dateEl.textContent = `Data da Oportunidade: ${formatDate(card.created_at)}`;
+        } else {
+            const newDateEl = document.createElement('small');
+            newDateEl.className = 'card-date text-muted';
+            newDateEl.textContent = `Data da Oportunidade: ${formatDate(card.created_at)}`;
+            existing.appendChild(newDateEl);
         }
         if (oldColumn != card.column_id) {
             const columnDiv = document.querySelector(`#column-${card.column_id}`);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -100,9 +100,9 @@
                      data-conversation-id="{{ card.conversation_id|default('') }}"
                      data-vendedor-id="{{ card.vendedor_id }}"
                      data-column-id="{{ column.id }}"
-                     data-created-at="{{ card.created_at.isoformat() }}"
-                     data-custom='{{ card.custom_data | tojson }}'
-                    onclick="openEditModal(this)">
+                    data-created-at="{{ card.created_at.isoformat() }}"
+                    data-custom='{{ card.custom_data | tojson }}'
+                   onclick="openEditModal(this)">
                     <div class="card-title">{{ card.title }}</div>
                     <div class="card-desc">
                         {{ card.valor_negociado|brl }} - {{ card.vendedor.user_name }}
@@ -112,6 +112,7 @@
                         </a>
                         {% endif %}
                     </div>
+                    <small class="card-date text-muted">Data da Oportunidade: {{ card.created_at.strftime('%d/%m/%Y') }}</small>
                 </div>
                 {% endfor %}
             </div>


### PR DESCRIPTION
## Summary
- show opportunity date on kanban cards in templates and JS
- include formatDate helper
- style new card footer text for light and dark themes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - flask)*

------
https://chatgpt.com/codex/tasks/task_e_6888d8d10afc832dae570ce073cb1251