### PR TITLE
Add filter toggle button

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -66,3 +66,26 @@ body.dark-mode {
 .card-date {
     font-size: 0.8rem;
 }
+
+header {
+    position: relative;
+}
+
+.filter-toggle-btn {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    transform: translateY(50%);
+    z-index: 10;
+}
+
+#filterForm {
+    transition: transform 0.3s ease, opacity 0.3s ease;
+    transform-origin: left;
+}
+
+#filterForm.filters-hidden {
+    transform: translateX(-100%);
+    opacity: 0;
+    pointer-events: none;
+}

--- a/app/static/js/kanban.js
+++ b/app/static/js/kanban.js
@@ -365,6 +365,14 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (_) {}
     };
 
+    const filterToggleBtn = document.getElementById('filterToggleBtn');
+    const filterForm = document.getElementById('filterForm');
+    if (filterToggleBtn && filterForm) {
+        filterToggleBtn.addEventListener('click', () => {
+            filterForm.classList.toggle('filters-hidden');
+        });
+    }
+
     ['filterTitle','filterValorMin','filterValorMax','filterVendedor','filterDateFrom','filterDateTo'].forEach(id => {
         const el = document.getElementById(id);
         if (el) el.addEventListener('input', filterCards);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,7 @@
 {% set dark = g.user.empresa.dark_mode %}
 <body class="{{ 'dark-mode' if dark else '' }}" data-user-id="{{ g.user.id }}">
 <div class="container py-4">
-    <header class="d-flex justify-content-between align-items-center mb-4">
+    <header class="d-flex justify-content-between align-items-center mb-4 position-relative">
         <div class="d-flex align-items-center gap-3">
             <img src="{{ url_for('static', filename='images/logo.png') }}" alt="Logo" class="header-logo">
             {% if panels %}
@@ -44,6 +44,9 @@
         <a href="{{ url_for('superadmin.dashboard') }}" class="btn btn-primary py-2 px-3">Painel Super-Admin</a>
         {% endif %}
         </div>
+        <button id="filterToggleBtn" type="button" class="btn btn-outline-secondary filter-toggle-btn">
+            <i class="fa-solid fa-filter"></i>
+        </button>
     </header>
     <form id="filterForm" class="row g-2 align-items-end mb-3">
         <div class="col-sm-3">


### PR DESCRIPTION
## Summary
- add filter toggle button to header and slide-out animation
- style button position and filter form transition
- wire up toggle logic in JS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688a02169ff4832d9002156d77289ace