### PR TITLE
Update filter header layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -74,18 +74,30 @@ header {
 .filter-toggle-btn {
     position: absolute;
     bottom: 0;
-    left: 0;
+    right: 0;
     transform: translateY(50%);
     z-index: 10;
 }
 
+.filter-toggle-btn i {
+    color: #6f42c1;
+}
+
 #filterForm {
-    transition: transform 0.3s ease, opacity 0.3s ease;
-    transform-origin: left;
+    position: absolute;
+    bottom: 0;
+    right: 3rem;
+    transform: translateY(50%);
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    align-items: flex-end;
 }
 
 #filterForm.filters-hidden {
-    transform: translateX(-100%);
-    opacity: 0;
-    pointer-events: none;
+    display: none;
+}
+
+#filterForm .filter-group {
+    width: 160px;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -48,20 +48,20 @@
             <i class="fa-solid fa-filter"></i>
         </button>
     </header>
-    <form id="filterForm" class="row g-2 align-items-end mb-3">
-        <div class="col-sm-3">
+    <form id="filterForm" class="d-flex gap-2 align-items-end mb-3 filters-hidden">
+        <div class="filter-group d-flex flex-column">
             <label class="form-label" for="filterTitle">Título</label>
             <input type="text" id="filterTitle" class="form-control" placeholder="Buscar título">
         </div>
-        <div class="col-sm-2">
+        <div class="filter-group d-flex flex-column">
             <label class="form-label" for="filterValorMin">Valor mín.</label>
             <input type="number" step="0.01" id="filterValorMin" class="form-control">
         </div>
-        <div class="col-sm-2">
+        <div class="filter-group d-flex flex-column">
             <label class="form-label" for="filterValorMax">Valor máx.</label>
             <input type="number" step="0.01" id="filterValorMax" class="form-control">
         </div>
-        <div class="col-sm-2">
+        <div class="filter-group d-flex flex-column">
             <label class="form-label" for="filterVendedor">Vendedor</label>
             <select id="filterVendedor" class="form-select">
                 <option value="">Todos</option>
@@ -70,7 +70,7 @@
                 {% endfor %}
             </select>
         </div>
-        <div class="col-sm-3">
+        <div class="filter-group d-flex flex-column">
             <label class="form-label" for="filterDateFrom">Data Oportunidade</label>
             <div class="d-flex gap-2">
                 <input type="date" id="filterDateFrom" class="form-control">


### PR DESCRIPTION
## Summary
- reposition filter toggle to bottom right of header
- hide filter inputs by default and display them inline next to the toggle
- color the filter icon purple

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement blinker==1.9.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688a05141298832dbf69a757a2482ca7