### PR TITLE
Adjust filter toggle UI

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -74,18 +74,34 @@ header {
 .filter-toggle-btn {
     position: absolute;
     bottom: 0;
-    left: 0;
+    right: 0;
     transform: translateY(50%);
     z-index: 10;
 }
 
+.filter-toggle-btn i {
+    color: #0747A6;
+}
+
 #filterForm {
+    position: absolute;
+    bottom: 0;
+    right: 3rem;
+    transform: translateY(50%);
     transition: transform 0.3s ease, opacity 0.3s ease;
-    transform-origin: left;
+    transform-origin: right;
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: nowrap;
 }
 
 #filterForm.filters-hidden {
-    transform: translateX(-100%);
+    transform: translate(100%, 50%);
     opacity: 0;
     pointer-events: none;
+}
+
+#filterForm .form-control,
+#filterForm .form-select {
+    width: 10rem;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -47,37 +47,37 @@
         <button id="filterToggleBtn" type="button" class="btn btn-outline-secondary filter-toggle-btn">
             <i class="fa-solid fa-filter"></i>
         </button>
-    </header>
-    <form id="filterForm" class="row g-2 align-items-end mb-3">
-        <div class="col-sm-3">
-            <label class="form-label" for="filterTitle">Título</label>
-            <input type="text" id="filterTitle" class="form-control" placeholder="Buscar título">
-        </div>
-        <div class="col-sm-2">
-            <label class="form-label" for="filterValorMin">Valor mín.</label>
-            <input type="number" step="0.01" id="filterValorMin" class="form-control">
-        </div>
-        <div class="col-sm-2">
-            <label class="form-label" for="filterValorMax">Valor máx.</label>
-            <input type="number" step="0.01" id="filterValorMax" class="form-control">
-        </div>
-        <div class="col-sm-2">
-            <label class="form-label" for="filterVendedor">Vendedor</label>
-            <select id="filterVendedor" class="form-select">
-                <option value="">Todos</option>
-                {% for vendedor in vendedores %}
-                <option value="{{ vendedor.id }}">{{ vendedor.user_name }}</option>
-                {% endfor %}
-            </select>
-        </div>
-        <div class="col-sm-3">
-            <label class="form-label" for="filterDateFrom">Data Oportunidade</label>
-            <div class="d-flex gap-2">
-                <input type="date" id="filterDateFrom" class="form-control">
-                <input type="date" id="filterDateTo" class="form-control">
+        <form id="filterForm" class="row g-2 align-items-end mb-3 filters-hidden">
+            <div class="col-sm-3">
+                <label class="form-label" for="filterTitle">Título</label>
+                <input type="text" id="filterTitle" class="form-control" placeholder="Buscar título">
             </div>
-        </div>
-    </form>
+            <div class="col-sm-2">
+                <label class="form-label" for="filterValorMin">Valor mín.</label>
+                <input type="number" step="0.01" id="filterValorMin" class="form-control">
+            </div>
+            <div class="col-sm-2">
+                <label class="form-label" for="filterValorMax">Valor máx.</label>
+                <input type="number" step="0.01" id="filterValorMax" class="form-control">
+            </div>
+            <div class="col-sm-2">
+                <label class="form-label" for="filterVendedor">Vendedor</label>
+                <select id="filterVendedor" class="form-select">
+                    <option value="">Todos</option>
+                    {% for vendedor in vendedores %}
+                    <option value="{{ vendedor.id }}">{{ vendedor.user_name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-sm-3">
+                <label class="form-label" for="filterDateFrom">Data Oportunidade</label>
+                <div class="d-flex gap-2">
+                    <input type="date" id="filterDateFrom" class="form-control">
+                    <input type="date" id="filterDateTo" class="form-control">
+                </div>
+            </div>
+        </form>
+    </header>
     <div id="kanbanTopScroll" class="kanban-top-scroll"><div></div></div>
     <div class="kanban-board-wrapper">
     <div class="kanban-board row flex-nowrap g-3">


### PR DESCRIPTION
## Summary
- move filter form into header and hide it by default
- slide filter controls from right to left
- place toggle button in bottom-right
- color filter icon purple
- style inputs for single-line layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688a081ef024832daa2b8ed88d1931e8