### PR TITLE
Fix filter input layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -67,8 +67,12 @@ body.dark-mode {
     font-size: 0.8rem;
 }
 
-header {
+#kanbanHeader {
     position: relative;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+    align-items: center;
 }
 
 .filter-toggle-btn {
@@ -84,25 +88,24 @@ header {
 }
 
 #filterForm {
-    position: absolute;
-    bottom: -1.5rem;
-    left: 0;
-    right: 0;
-    transform: translateY(50%);
-    transition: transform 0.3s ease, opacity 0.3s ease;
-    transform-origin: right;
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
     gap: 0.5rem;
-    flex-wrap: nowrap;
+    margin-top: 0.5rem;
+    grid-column: 1 / -1;
 }
 
 #filterForm.filters-hidden {
-    transform: scaleX(0);
-    opacity: 0;
-    pointer-events: none;
+    display: none;
 }
 
 #filterForm .form-control,
 #filterForm .form-select {
     width: 100%;
+}
+
+#filterForm .date-range {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,7 @@
 {% set dark = g.user.empresa.dark_mode %}
 <body class="{{ 'dark-mode' if dark else '' }}" data-user-id="{{ g.user.id }}">
 <div class="container py-4">
-    <header class="d-flex justify-content-between align-items-center mb-4 position-relative">
+    <header id="kanbanHeader" class="mb-4 position-relative">
         <div class="d-flex align-items-center gap-3">
             <img src="{{ url_for('static', filename='images/logo.png') }}" alt="Logo" class="header-logo">
             {% if panels %}
@@ -47,21 +47,17 @@
         <a href="{{ url_for('superadmin.dashboard') }}" class="btn btn-primary py-2 px-3">Painel Super-Admin</a>
         {% endif %}
         </div>
-        <form id="filterForm" class="row g-2 align-items-end mb-3 filters-hidden">
-            <div class="col-sm-3">
-                <label class="form-label" for="filterTitle">Título</label>
-                <input type="text" id="filterTitle" class="form-control" placeholder="Buscar título">
+        <form id="filterForm" class="mb-3 filters-hidden">
+            <div>
+                <input type="text" id="filterTitle" class="form-control" placeholder="Título">
             </div>
-            <div class="col-sm-2">
-                <label class="form-label" for="filterValorMin">Valor mín.</label>
-                <input type="number" step="0.01" id="filterValorMin" class="form-control">
+            <div>
+                <input type="number" step="0.01" id="filterValorMin" class="form-control" placeholder="Valor mín.">
             </div>
-            <div class="col-sm-2">
-                <label class="form-label" for="filterValorMax">Valor máx.</label>
-                <input type="number" step="0.01" id="filterValorMax" class="form-control">
+            <div>
+                <input type="number" step="0.01" id="filterValorMax" class="form-control" placeholder="Valor máx.">
             </div>
-            <div class="col-sm-2">
-                <label class="form-label" for="filterVendedor">Vendedor</label>
+            <div>
                 <select id="filterVendedor" class="form-select">
                     <option value="">Todos</option>
                     {% for vendedor in vendedores %}
@@ -69,12 +65,9 @@
                     {% endfor %}
                 </select>
             </div>
-            <div class="col-sm-3">
-                <label class="form-label" for="filterDateFrom">Data Oportunidade</label>
-                <div class="d-flex gap-2">
-                    <input type="date" id="filterDateFrom" class="form-control">
-                    <input type="date" id="filterDateTo" class="form-control">
-                </div>
+            <div class="date-range">
+                <input type="date" id="filterDateFrom" class="form-control" placeholder="Início">
+                <input type="date" id="filterDateTo" class="form-control" placeholder="Fim">
             </div>
         </form>
     </header>


### PR DESCRIPTION
## Summary
- ensure filter inputs appear on one line using CSS grid
- simplify filter form markup and keep date inputs aligned

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688a1704d3e0832d8d2f70a25d43b6c5