### PR TITLE
Update icon colors for dark mode

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -87,6 +87,18 @@ body.dark-mode {
     color: #0747A6;
 }
 
+/* Dark mode button styles */
+.dark-mode #toggleThemeForm button,
+.dark-mode .filter-toggle-btn {
+    color: #fff;
+    border-color: #fff;
+}
+
+.dark-mode #toggleThemeForm i,
+.dark-mode .filter-toggle-btn i {
+    color: #fff;
+}
+
 #filterForm {
     display: grid;
     grid-template-columns: repeat(5, 1fr);


### PR DESCRIPTION
## Summary
- style icons for light/dark toggle and filter in dark mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688a1c58efb0832d997ed31d008b5f2e